### PR TITLE
Complete transition from `base`

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/*est/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
       - name: Upload code coverage report

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -27,5 +27,5 @@ jobs:
         uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/*est/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+[![Ubuntu build][ubuntu-build-badge]][gh-actions]
+[![Windows build][windows-build-badge]][gh-actions]
+[![codecov][codecov-badge]][codecov] &nbsp;
+[![license][license-badge]][license]
+
+# Spine Logging
+
+Spine Logging is a library for (potentially multi-platform) Kotlin and Java projects.
+Only JMV implementation for Kotlin is currently provided, with JS implementation being
+of priority.
+
+The library is largely inspired by [Google Flogger][flogger] logging API, and introduction of
+fluent logging API in [SLF4J in v2.0.0][fluent-slf4j].
+
+
+## Gradle dependency
+To use Spine Logging in your Gradle project:
+
+```kotlin
+dependencies {
+    implementation("io.spine.tools:spine-logging:${version}")
+}
+```
+
+[codecov]: https://codecov.io/gh/SpineEventEngine/logging
+[codecov-badge]: https://codecov.io/gh/SpineEventEngine/logging/branch/master/graph/badge.svg
+[license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
+[license]: http://www.apache.org/licenses/LICENSE-2.0
+[gh-actions]: https://github.com/SpineEventEngine/logging/actions
+[ubuntu-build-badge]: https://github.com/SpineEventEngine/logging/actions/workflows/build-on-ubuntu.yml/badge.svg
+[windows-build-badge]: https://github.com/SpineEventEngine/logging/actions/workflows/build-on-windows.yml/badge.svg
+[flogger]: https://google.github.io/flogger
+[fluent-slf4j]: https://www.slf4j.org/manual.html#fluent

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,13 @@ kotlin {
     }
 }
 
+detekt {
+    source = files(
+        "src/commonMain",
+        "src/jvmMain"
+    )
+}
+
 val jvmTest: Task by tasks.getting {
     (this as Test).run {
         useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,16 @@ tasks {
     registerTestTasks()
 }
 
+kover {
+    useJacocoTool()
+}
+
+koverReport {
+    xml {
+        onCheck = true
+    }
+}
+
 publishing {
     publications.withType<MavenPublication> {
         if (name.contains("jvm", true)) {
@@ -148,7 +158,6 @@ publishing {
     }
 }
 
-apply(plugin="jacoco-kmm-jvm")
 CheckStyleConfig.applyTo(project)
 // Apply Javadoc configuration here (and not right after the `plugins` block)
 // because the `javadoc` task is added when the `kotlin` block `withJava` is applied.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ import io.spine.internal.gradle.report.pom.PomGenerator
 import io.spine.internal.gradle.standardToSpineSdk
 import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
+import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 
@@ -53,6 +54,7 @@ plugins {
     `project-report`
     `detekt-code-analysis`
     `gradle-doctor`
+    id("org.jetbrains.kotlinx.kover") version "0.7.0-Alpha"
 }
 apply(from = "$rootDir/version.gradle.kts")
 apply<IncrementGuard>()
@@ -113,6 +115,13 @@ kotlin {
     }
 }
 
+val jvmTest: Task by tasks.getting {
+    (this as Test).run {
+        useJUnitPlatform()
+        configureLogging()
+    }
+}
+
 tasks {
     withType<KotlinCompile>().configureEach {
         setFreeCompilerArgs()
@@ -120,14 +129,13 @@ tasks {
     withType<KotlinTest>().configureEach {
         reports.junitXml.required.set(true)
     }
-    registerTestTasks()
-}
-
-val jvmTest: Task by tasks.getting {
-    (this as Test).run {
-        useJUnitPlatform()
-        configureLogging()
+    withType<KotlinJvmTest>().configureEach {
+        reports.junitXml.required.set(true)
     }
+    withType<Test>().configureEach {
+        reports.junitXml.required.set(true)
+    }
+    registerTestTasks()
 }
 
 publishing {
@@ -148,4 +156,3 @@ JavadocConfig.applyTo(project)
 PomGenerator.applyTo(project)
 LicenseReporter.generateReportIn(project)
 LicenseReporter.mergeAllReports(project)
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ import io.spine.internal.gradle.publish.spinePublishing
 import io.spine.internal.gradle.report.license.LicenseReporter
 import io.spine.internal.gradle.report.pom.PomGenerator
 import io.spine.internal.gradle.standardToSpineSdk
+import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -119,7 +120,10 @@ tasks {
 }
 
 val jvmTest: Task by tasks.getting {
-    (this as Test).useJUnitPlatform()
+    (this as Test).run {
+        useJUnitPlatform()
+        configureLogging()
+    }
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ import io.spine.internal.gradle.standardToSpineSdk
 import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 
 plugins {
    `maven-publish`
@@ -115,6 +116,9 @@ kotlin {
 tasks {
     withType<KotlinCompile>().configureEach {
         setFreeCompilerArgs()
+    }
+    withType<KotlinTest>().configureEach {
+        reports.junitXml.required.set(true)
     }
     registerTestTasks()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,7 @@ import io.spine.internal.gradle.report.pom.PomGenerator
 import io.spine.internal.gradle.standardToSpineSdk
 import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
-import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 
 plugins {
    `maven-publish`
@@ -125,15 +123,6 @@ val jvmTest: Task by tasks.getting {
 tasks {
     withType<KotlinCompile>().configureEach {
         setFreeCompilerArgs()
-    }
-    withType<KotlinTest>().configureEach {
-        reports.junitXml.required.set(true)
-    }
-    withType<KotlinJvmTest>().configureEach {
-        reports.junitXml.required.set(true)
-    }
-    withType<Test>().configureEach {
-        reports.junitXml.required.set(true)
     }
     registerTestTasks()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.checkstyle.CheckStyleConfig
 import io.spine.internal.gradle.javadoc.JavadocConfig
 import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
+import io.spine.internal.gradle.publish.IncrementGuard
 import io.spine.internal.gradle.publish.PublishingRepos
 import io.spine.internal.gradle.publish.javadocJar
 import io.spine.internal.gradle.publish.spinePublishing
@@ -51,8 +52,8 @@ plugins {
     `detekt-code-analysis`
     `gradle-doctor`
 }
-
 apply(from = "$rootDir/version.gradle.kts")
+apply<IncrementGuard>()
 group = "io.spine"
 version = rootProject.extra["versionToPublish"]!!
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
@@ -110,7 +110,7 @@ private fun DartTasks.stagePubPublication(): TaskProvider<Copy> =
         into(publicationDir)
 
         doLast {
-            logger.debug("Pub publication is prepared in directory `$publicationDir`.")
+            logger.debug("Pub publication is prepared in directory `{}`.", publicationDir)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,11 @@
 #
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC
+
+# suppress inspection "UnusedProperty"
+# The below property enables generation of XML reports for tests.
+# If this flag is false, it causes `KotlinTestReport` task to replace these reports with one
+# consolidated HTML report.
+# See: https://github.com/JetBrains/kotlin/blob/9fd05632f0d7f074b6544527e73eb0fbb2fb1ef2/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestReport.kt#L20
+# See: https://youtrack.jetbrains.com/issue/KT-32608
+kotlin.tests.individualTaskReports=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,3 @@
 #
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC
-
-# suppress inspection "UnusedProperty"
-# The below property enables generation of XML reports for tests.
-# If this flag is false, it causes `KotlinTestReport` task to replace these reports with one
-# consolidated HTML report.
-# See: https://github.com/JetBrains/kotlin/blob/9fd05632f0d7f074b6544527e73eb0fbb2fb1ef2/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestReport.kt#L20
-# See: https://youtrack.jetbrains.com/issue/KT-32608
-kotlin.tests.individualTaskReports=true

--- a/license-report.md
+++ b/license-report.md
@@ -738,4 +738,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 14:20:52 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 18 14:36:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -445,6 +445,10 @@
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.30.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.31.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -473,6 +477,10 @@
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 16.0.2.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
 1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
@@ -514,6 +522,18 @@
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-analysis-intellij. **Version** : 1.8.10.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : coverage-report. **Version** : 1.0.18.
+     * **Project URL:** [https://github.com/JetBrains/coverage-report](https://github.com/JetBrains/coverage-report)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.709.
+     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-reporter. **Version** : 1.0.709.
+     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
@@ -672,6 +692,10 @@
      * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.json. **Name** : json. **Version** : 20210307.
+     * **Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **License:** [The JSON License](http://json.org/license.html)
+
 1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.3.
      * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
      * **License:** [The MIT License](https://jsoup.org/license)
@@ -738,4 +762,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 00:45:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 18 14:11:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -445,10 +445,6 @@
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
-1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.30.
-     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.31.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -477,10 +473,6 @@
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 16.0.2.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.3.1.**No license information found**
 1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.3.1.
@@ -522,18 +514,6 @@
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-analysis-intellij. **Version** : 1.8.10.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : coverage-report. **Version** : 1.0.18.
-     * **Project URL:** [https://github.com/JetBrains/coverage-report](https://github.com/JetBrains/coverage-report)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.709.
-     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-reporter. **Version** : 1.0.709.
-     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
@@ -692,10 +672,6 @@
      * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.json. **Name** : json. **Version** : 20210307.
-     * **Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
-     * **License:** [The JSON License](http://json.org/license.html)
-
 1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.3.
      * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
      * **License:** [The MIT License](https://jsoup.org/license)
@@ -762,4 +738,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 14:11:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 18 14:20:52 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -738,4 +738,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 00:34:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 18 00:45:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -738,4 +738,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 14:36:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 18 14:50:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -94,16 +94,6 @@ all modules and does not describe the project structure per-subproject.
     <version>1.8.10</version>
   </dependency>
   <dependency>
-    <groupId>org.jetbrains.intellij.deps</groupId>
-    <artifactId>intellij-coverage-agent</artifactId>
-    <version>1.0.709</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.intellij.deps</groupId>
-    <artifactId>intellij-coverage-reporter</artifactId>
-    <version>1.0.709</version>
-  </dependency>
-  <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-compiler-embeddable</artifactId>
     <version>1.8.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,16 @@ all modules and does not describe the project structure per-subproject.
     <version>1.8.10</version>
   </dependency>
   <dependency>
+    <groupId>org.jetbrains.intellij.deps</groupId>
+    <artifactId>intellij-coverage-agent</artifactId>
+    <version>1.0.709</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.intellij.deps</groupId>
+    <artifactId>intellij-coverage-reporter</artifactId>
+    <version>1.0.709</version>
+  </dependency>
+  <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-compiler-embeddable</artifactId>
     <version>1.8.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>logging</artifactId>
-<version>2.0.0-SNAPSHOT.180</version>
+<version>2.0.0-SNAPSHOT.181</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/commonMain/kotlin/io/spine/logging/Logger.kt
+++ b/src/commonMain/kotlin/io/spine/logging/Logger.kt
@@ -41,11 +41,12 @@ public abstract class Logger<API: LoggingApi<API>>(
             return api
         }
         val loggingDomain = loggingDomainOf(cls)
-        if (loggingDomain === LoggingDomain.noOp) {
-            return api
+        return if (loggingDomain === LoggingDomain.noOp) {
+            api
+        } else {
+            @Suppress("UNCHECKED_CAST") // Safe to cast since delegates to the same interface.
+            WithLoggingDomain(loggingDomain, api) as API
         }
-        @Suppress("UNCHECKED_CAST") // Safe to cast since delegates to the same interface.
-        return WithLoggingDomain(loggingDomain, api) as API
     }
 
     protected abstract fun createApi(level: Level): API

--- a/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -39,14 +39,18 @@ public interface LoggingApi<API: LoggingApi<API>> {
     public open class NoOp<API: LoggingApi<API>>: LoggingApi<API> {
 
         @Suppress("UNCHECKED_CAST")
-        protected fun noOp(): API = this as API
+        protected fun self(): API = this as API
 
-        override fun withCause(cause: Throwable): API = noOp()
+        override fun withCause(cause: Throwable): API = self()
 
         override fun isEnabled(): Boolean = false
 
-        override fun log() {}
+        override fun log() {
+            // no-op
+        }
 
-        override fun log(message: () -> String) {}
+        override fun log(message: () -> String) {
+            // no-op
+        }
     }
 }

--- a/src/jvmMain/kotlin/io/spine/logging/LoggingDomainClassValue.kt
+++ b/src/jvmMain/kotlin/io/spine/logging/LoggingDomainClassValue.kt
@@ -56,6 +56,7 @@ internal object LoggingDomainClassValue: ClassValue<LoggingDomain>() {
 
     internal fun get(cls: KClass<*>) = get(cls.java)
 
+    @Suppress("ReturnCount") // to ease the flow on null results
     override fun computeValue(javaClass: Class<*>): LoggingDomain {
         with(javaClass.kotlin) {
             findWithNesting<LoggingDomain>()?.let {
@@ -75,6 +76,7 @@ internal object LoggingDomainClassValue: ClassValue<LoggingDomain>() {
 /**
  * Attempts to find the annotation of type [T] in this [KClass] or enclosing classes.
  */
+@Suppress("ReturnCount") // to ease the flow on null results
 private inline fun <reified T: Annotation> KClass<*>.findWithNesting(): T? {
     findAnnotation<T>()?.let {
         return it

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.180")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.181")


### PR DESCRIPTION
This PR completes extraction of `logging` from `base` into a dedicated repository.

### Notable changes
 * GitHub workflows were updated to upload JUnit test reports from all subdirectories of `build/test-results/` with names ending on `est` to take into account test task from Kotlin KMM project (e.g. `jvmTest`). This change will be propagated to `config` in one of the following PRs.
 * Kover Gradle Plugin was added to avoid manual configuration of Kotlin KMM test tasks.
 * `kotlin.tests.individualTaskReports=true` flag was added to `gradle.properties` to allow generation of XML test report files. It turns out that Kover still relies on this flag.
