### PR TITLE
Move convenience `Logger` method back under the class

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -37,6 +37,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="Dart">

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -740,12 +740,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:54:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:35 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1535,12 +1535,12 @@ This report was generated on **Mon May 29 19:54:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:54:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:36 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2326,12 +2326,12 @@ This report was generated on **Mon May 29 19:54:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:36 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3109,12 +3109,12 @@ This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3904,12 +3904,12 @@ This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4703,12 +4703,12 @@ This report was generated on **Mon May 29 19:55:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5388,12 +5388,12 @@ This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6171,12 +6171,12 @@ This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6954,4 +6954,4 @@ This report was generated on **Mon May 29 19:55:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 29 19:55:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 01 16:38:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
@@ -72,24 +72,35 @@ public abstract class Logger<API: LoggingApi<API>>(
      * implementation of the [API] type.
      */
     protected abstract fun createApi(level: Level): API
+
+    /*
+     * IMPLEMENTATION NOTE
+     *
+     * The following methods are not implemented as extension functions in order to
+     * preserve the calling site which is supposed to be set by `createApi()` method
+     * of the concrete logger implementation.
+     *
+     * Had we implemented these methods as extension functions, the calling site would
+     * be `LoggerKt` class, which is not what we want.
+     */
+
+    /**
+     * A convenience function for `at(Level.DEBUG)`.
+     */
+    public fun atDebug(): API = at(Level.DEBUG)
+
+    /**
+     * A convenience function for `at(Level.INFO)`.
+     */
+    public fun atInfo(): API = at(Level.INFO)
+
+    /**
+     * A convenience function for `at(Level.WARNING)`.
+     */
+    public fun atWarning(): API = at(Level.WARNING)
+
+    /**
+     * A convenience function for `at(Level.ERROR)`.
+     */
+    public fun atError(): API = at(Level.ERROR)
 }
-
-/**
- * A convenience function for `at(Level.DEBUG)`.
- */
-public fun <API: LoggingApi<API>> Logger<API>.atDebug(): API = at(Level.DEBUG)
-
-/**
- * A convenience function for `at(Level.INFO)`.
- */
-public fun <API: LoggingApi<API>> Logger<API>.atInfo(): API = at(Level.INFO)
-
-/**
- * A convenience function for `at(Level.WARNING)`.
- */
-public fun <API: LoggingApi<API>> Logger<API>.atWarning(): API = at(Level.WARNING)
-
-/**
- * A convenience function for `at(Level.ERROR)`.
- */
-public fun <API: LoggingApi<API>> Logger<API>.atError(): API = at(Level.ERROR)

--- a/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
@@ -85,22 +85,27 @@ public abstract class Logger<API: LoggingApi<API>>(
      */
 
     /**
-     * A convenience function for `at(Level.DEBUG)`.
+     * A convenience method for `at(Level.TRACE)`.
+     */
+    public fun atTrace(): API = at(Level.TRACE)
+
+    /**
+     * A convenience method for `at(Level.DEBUG)`.
      */
     public fun atDebug(): API = at(Level.DEBUG)
 
     /**
-     * A convenience function for `at(Level.INFO)`.
+     * A convenience method for `at(Level.INFO)`.
      */
     public fun atInfo(): API = at(Level.INFO)
 
     /**
-     * A convenience function for `at(Level.WARNING)`.
+     * A convenience method for `at(Level.WARNING)`.
      */
     public fun atWarning(): API = at(Level.WARNING)
 
     /**
-     * A convenience function for `at(Level.ERROR)`.
+     * A convenience method for `at(Level.ERROR)`.
      */
     public fun atError(): API = at(Level.ERROR)
 }

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerFactorySpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerFactorySpec.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging
+
+import io.kotest.matchers.shouldBe
+import io.spine.logging.LoggingFactory.loggingDomainOf
+import io.spine.logging.given.domain.AnnotatedClass
+import io.spine.logging.given.domain.IndirectlyAnnotatedClass
+import io.spine.logging.given.domain.nested.NonAnnotatedNestedPackageClass
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`JvmLoggerFactory` should")
+internal class JvmLoggerFactorySpec {
+
+    @Nested
+    inner class `obtain a logging domain for` {
+
+        @Test
+        fun `directly annotated class`() {
+            val loggingDomain = loggingDomainOf(AnnotatedClass::class)
+            loggingDomain.name shouldBe "OnClass"
+        }
+
+        @Test
+        fun `a class with annotated package`() {
+            val loggingDomain = loggingDomainOf(IndirectlyAnnotatedClass::class)
+            loggingDomain.name shouldBe "OnPackage"
+        }
+
+        @Test
+        fun `a class in a nested non-annotated package`() {
+            val loggingDomain = loggingDomainOf(NonAnnotatedNestedPackageClass::class)
+            loggingDomain.name shouldBe "OnPackage"
+        }
+    }
+}

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -41,9 +41,12 @@ internal class JvmLoggerSpec {
     @Test
     fun `create no-op instance when logging level is too low`() {
         // The default level (with Java logging as the backend) is `INFO`.
+        (logger.atTrace() is LoggingApi.NoOp) shouldBe true
         (logger.atDebug() is LoggingApi.NoOp) shouldBe true
 
         (logger.atInfo() is LoggingApi.NoOp) shouldBe false
+        (logger.atWarning() is LoggingApi.NoOp) shouldBe false
+        (logger.atError() is LoggingApi.NoOp) shouldBe false
     }
 
     @Test

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -55,4 +55,16 @@ internal class JvmLoggerSpec {
         }
         consoleOutput shouldContain "[OnPackage] $msg"
     }
+
+    @Test
+    fun `contain the name of the logging class`() {
+        val expectedMsg = "METHOD REFERENCE TEST"
+        val consoleOutput = tapSystemErrAndOut {
+            logger.atInfo().log { expectedMsg }
+        }
+        val expectedMethodReference = "contain the name of the logging class".replace(' ', '_')
+        consoleOutput shouldContain this::class.java.name
+        consoleOutput shouldContain expectedMsg
+        consoleOutput shouldContain expectedMethodReference
+    }
 }

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -57,9 +57,8 @@ internal class JvmLoggerSpec {
             System.err.println(consoleCheck)
         }
         consoleOutput shouldContain consoleCheck
-        val expectedMethodReference =
-            ("produce the output with the name of" +
-                    " the logging class and calling method") //.replace(' ', '_')
+        val expectedMethodReference = "produce the output with the name of" +
+                " the logging class and calling method"
         consoleOutput shouldContain this::class.java.name
         consoleOutput shouldContain expectedMsg
         consoleOutput shouldContain expectedMethodReference

--- a/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.io.PrintStream
+
+/**
+ * Executes the given [action] and returns the text printed to the console.
+ *
+ * @see TapConsole
+ */
+internal fun tapConsole(action: () -> Unit): String {
+    val bytes = TapBytesStream(4096)
+    val printer = PrintStream(bytes, true)
+    TapConsole.executeWithStream(printer, action)
+    return bytes.output()
+}
+
+/**
+ * This object is a test fixture that allows to tap the output
+ * sent to [System.out] and [System.err] when [executing][executeWithStream]
+ * a code block which potentially can produce console output.
+ *
+ * This arrangement is needed as a workaround for the fact that Java Logging framework
+ * initializes the [ConsoleHandler][java.util.logging.ConsoleHandler] with the stream
+ * object assigned to [System.err] at the time of the calling parameterless constructor of
+ * [ConsoleHandler][java.util.logging.ConsoleHandler]. That's why replacing the value of
+ * [System.err] with a custom stream after the initialization of the logging framework has
+ * no effect for intercepting the output.
+ *
+ * During the initialization the object replaces both [System.out] and [System.err] with
+ * the custom streams which can be redirected. When [executeWithStream] is called,
+ * a stream passed as a parameter is used to replace the current streams. After the execution
+ * is complete, the original streams are restored.
+ */
+private object TapConsole {
+
+    private val out = RedirectingPrintStream(System.out)
+    private val err = RedirectingPrintStream(System.err)
+
+    init {
+        System.setOut(out)
+        System.setErr(err)
+    }
+
+    fun executeWithStream(stream: PrintStream, action: () -> Unit) {
+        out.redirect(stream)
+        err.redirect(stream)
+        try {
+            action()
+        } finally {
+            out.restore()
+            err.restore()
+        }
+    }
+}
+
+/**
+ * Redirects the output to the given [PrintStream] and restores the original
+ * stream when instructed.
+ */
+private class RedirectingPrintStream(
+    initial: PrintStream
+): PrintStream(DelegatingOutputStream(initial)) {
+
+    private val output = out as DelegatingOutputStream
+    private var prevStream: OutputStream = initial
+
+    fun redirect(newStream: PrintStream) {
+        prevStream = output.delegate
+        output.redirect(newStream)
+    }
+
+    fun restore() = output.redirect(prevStream)
+}
+
+/**
+ * A stream which performs writing via the [delegate].
+ */
+private class DelegatingOutputStream(var delegate: OutputStream): OutputStream()  {
+
+    override fun write(b: Int) =
+        delegate.write(b)
+
+    fun redirect(newOutputStream: OutputStream) {
+        delegate = newOutputStream
+    }
+}
+
+/**
+ * A typed replacement for [ByteArrayOutputStream] for easier debugging.
+ */
+private class TapBytesStream(size: Int): ByteArrayOutputStream(size) {
+
+    fun output(): String {
+        flush()
+        return toString()
+    }
+}

--- a/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
@@ -36,10 +36,9 @@ import java.io.PrintStream
  * @see TapConsole
  */
 internal fun tapConsole(action: () -> Unit): String {
-    val bytes = TapBytesStream(4096)
-    val printer = PrintStream(bytes, true)
-    TapConsole.executeWithStream(printer, action)
-    return bytes.output()
+    val tap = TapBytesStream(4096)
+    TapConsole.executeWithStream(tap, action)
+    return tap.output()
 }
 
 /**
@@ -116,10 +115,10 @@ private class DelegatingOutputStream(var delegate: OutputStream): OutputStream()
 /**
  * A typed replacement for [ByteArrayOutputStream] for easier debugging.
  */
-private class TapBytesStream(size: Int): ByteArrayOutputStream(size) {
+private class TapBytesStream(size: Int): PrintStream(ByteArrayOutputStream(size), true) {
 
     fun output(): String {
-        flush()
-        return toString()
+        out.flush()
+        return out.toString()
     }
 }

--- a/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/TapConsole.kt
@@ -41,30 +41,30 @@ internal fun tapConsole(action: () -> Unit): String {
 }
 
 /**
- * This object is a test fixture that allows to tap the output
- * sent to [System.out] and [System.err] when [executing][executeWithStream]
- * a code block which potentially can produce console output.
+ * This test fixture is designed to intercept and control output sent
+ * to [System.out] and [System.err] during the execution of a given code block
+ * when [executeWithStream] method is called.
  *
- * This arrangement is needed as a workaround for the fact that Java Logging framework
- * initializes the [ConsoleHandler][java.util.logging.ConsoleHandler] with the stream
- * assigned to [System.err] at the time of the calling parameterless constructor of
- * [ConsoleHandler][java.util.logging.ConsoleHandler]. That's why replacing the value of
- * [System.err] with a custom stream after the initialization of the logging framework has
- * no effect for intercepting the output. `ConsoleHandler` will still use the originally
- * remembered value of [System.err].
+ * The purpose of this test fixture is to address a limitation of the Java Logging
+ * framework, where the [ConsoleHandler][java.util.logging.ConsoleHandler] is initialized
+ * with the stream tied to [System.err] during the parameterless constructor call.
+ * This makes it impossible to replace [System.err] with a custom stream after
+ * the logging framework is initialized, as `ConsoleHandler` continues using
+ * the original [System.err] value.
  *
- * During the initialization the object replaces both [System.out] and [System.err] with
- * the custom streams which can be redirected. When [executeWithStream] is called,
- * a stream passed as a parameter is used to replace the current streams. After the execution
- * is complete, the original streams are restored.
+ * At initialization, this object replaces [System.out] and [System.err] with custom,
+ * redirectable streams. When [executeWithStream] is invoked, the current streams are
+ * replaced with a stream passed as an argument. Once the execution concludes,
+ * the original streams are reinstated.
  *
- * Since this fixture is `object`, which replaces [System.out] and [System.err] on
- * construction, we never restore the original streams. We do it deliberately to have
- * a reliable workaround for the Java Logging framework "fixation" on [System.err].
+ * This fixture is deliberately constructed as an `object` that doesn't restore
+ * the original streams after construction. This approach provides a reliable solution
+ * for the Java Logging framework's static binding to [System.err].
  *
- * Not restoring the streams is not a problem for our current tests. It might be an issue
- * for the tests executed in a broader context, which also deal the console output interception
- * especially in combination with wording around of Java Logging framework "peculiarities".
+ * Not restoring the streams does not affect our current testing requirements.
+ * However, for more extensive testing scenarios that also involve console output
+ * interception and complex interactions with Java Logging framework's quirks,
+ * this could potentially create issues.
  */
 private object TapConsole {
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.184</version>
+<version>2.0.0-SNAPSHOT.185</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.184")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.185")


### PR DESCRIPTION
This PR  moves `Logger.atDebug()`, `atInfo()`, and the like convenience methods back under the class. Previously the methods were arranged as extension functions, which resulted in a wrong call site produced for them. This was so because the call site was created as a caller of `Logger` class, while extension functions belonged to `LoggerKt` class.

We could kept `atXxx()` calls as extension functions _and_ alter the call site to be of caller of `LoggerKt` class. But it's too much of ceremony and performance impact just for being more idiomatic in Kotlin.

Also `Logger.atTrace()` convenience method was also added.

This PR also introduces text fixture for intercepting `System.out` and `System.err` in combination with using Java Logging framework as the backend. Please see `TapConsole.kt` file for details.
