### PR TITLE
Extend `LoggingApi` with `per(...)` method

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -740,12 +740,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:33:59 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:20 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1535,12 +1535,12 @@ This report was generated on **Fri Jun 16 12:33:59 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:01 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:21 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2326,12 +2326,12 @@ This report was generated on **Fri Jun 16 12:34:01 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:03 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:22 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3109,12 +3109,12 @@ This report was generated on **Fri Jun 16 12:34:03 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:05 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:23 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3904,12 +3904,12 @@ This report was generated on **Fri Jun 16 12:34:05 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:07 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:23 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4703,12 +4703,12 @@ This report was generated on **Fri Jun 16 12:34:07 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:08 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:24 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5388,12 +5388,12 @@ This report was generated on **Fri Jun 16 12:34:08 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:09 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:25 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6171,12 +6171,12 @@ This report was generated on **Fri Jun 16 12:34:09 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:10 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:26 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6954,4 +6954,4 @@ This report was generated on **Fri Jun 16 12:34:10 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 16 12:34:11 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 03 13:44:27 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -157,7 +157,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * `taskType`s to be rate-limited independently of each other:
      *
      * ```
-     * // We want to rate limit logging separately for all task types.
+     * // We want to rate limit logging separately for each task type.
      * logger.at(INFO)
      *       .per(task.type)
      *       .atMostEvery(30, SECONDS)

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -102,7 +102,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * ```
      * logger.atFine()
      *       .atMostEvery(2, SECONDS)
-     *       .log(...)
+     *       .log { ... }
      * ```
      *
      * logging would occur after 0s, 2.4s and 4.8s (not 4.2s), giving an effective
@@ -161,7 +161,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * logger.at(INFO)
      *       .per(task.type)
      *       .atMostEvery(30, SECONDS)
-     *       .log("Start task: %s", task.name);
+     *       .log { "Task started: ${task.name}." }
      * ```
      *
      * The `key` passed to this method should always be a variable.

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -140,6 +140,40 @@ public interface LoggingApi<API: LoggingApi<API>> {
     public fun atMostEvery(n: Int, unit: DurationUnit): API
 
     /**
+     * Aggregates stateful logging with respect to the given enum value.
+     *
+     * Normally log statements with conditional behavior (e.g., rate limiting)
+     * use the same state for each invocation (e.g., counters or timestamps).
+     * This method allows an additional qualifier to be given, which allows
+     * a different conditional state for each unique enum value.
+     *
+     * This only makes a difference for log statements, which use persistent
+     * state to control conditional behaviour (e.g., `atMostEvery()` or `every()`).
+     *
+     * It is most useful in helping to avoid cases where a rare event might
+     * never be logged due to rate limiting.
+     *
+     * For example, the following code will cause log statements with different
+     * `taskType`s to be rate-limited independently of each other:
+     *
+     * ```
+     * // We want to rate limit logging separately for all task types.
+     * logger.at(INFO)
+     *       .per(task.type)
+     *       .atMostEvery(30, SECONDS)
+     *       .log("Start task: %s", task.name);
+     * ```
+     *
+     * The `key` passed to this method should always be a variable.
+     * Passing of a constant has no effect.
+     *
+     * If multiple aggregation keys are added to a single log statement,
+     * then they all take effect and logging is aggregated by the unique
+     * combination of keys passed to all [per] methods.
+     */
+    public fun per(key: Enum<*>): API
+
+    /**
      * Returns `true` if logging is enabled at the level implied for this API.
      */
     public fun isEnabled(): Boolean
@@ -190,6 +224,11 @@ public interface LoggingApi<API: LoggingApi<API>> {
          * Does nothing.
          */
         override fun every(n: Int): API = noOp()
+
+        /**
+         * Does nothing.
+         */
+        override fun per(key: Enum<*>): API = noOp()
 
         /**
          * Does nothing.

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
@@ -97,6 +97,11 @@ private class ApiImpl(private val delegate: FluentLogger.Api): JvmLogger.Api {
         return this
     }
 
+    override fun per(key: Enum<*>): JvmLogger.Api {
+        delegate.per(key)
+        return this
+    }
+
     override fun isEnabled(): Boolean = delegate.isEnabled
 
     override fun log() = delegate.log()

--- a/logging/src/jvmTest/kotlin/io/spine/logging/given/LoggingRateForecasting.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/given/LoggingRateForecasting.kt
@@ -59,10 +59,31 @@ internal fun expectedRuns(invocations: Int, invocationRateLimit: Int): Int {
  *          the configured rate limitation
  */
 @Suppress("SameParameterValue") // Extracted to a method for better readability.
+@JvmName("expectedRunsPerTask") // JVM has a problem with the conflicting erasures.
 internal fun expectedRuns(
     invocations: Map<Task, Int>,
     invocationRateLimit: Int,
 ): Map<Task, Int> = invocations.mapValues { entry ->
+    expectedRuns(entry.value, invocationRateLimit)
+}
+
+/**
+ * Calculates how many times a logging statement should be executed for each
+ * combination of enum values when the execution rate is limited by
+ * [LoggingApi.every] method.
+ *
+ * @param invocations
+ *          number of times a logging statement is invoked for each combination
+ *          of enum values
+ * @param invocationRateLimit
+ *          the configured rate limitation
+ */
+@Suppress("SameParameterValue") // Extracted to a method for better readability.
+@JvmName("expectedRunsPerTasks") // JVM has a problem with the conflicting erasures.
+internal fun expectedRuns(
+    invocations: Map<Set<Task>, Int>,
+    invocationRateLimit: Int,
+): Map<Set<Task>, Int> = invocations.mapValues { entry ->
     expectedRuns(entry.value, invocationRateLimit)
 }
 

--- a/logging/src/jvmTest/kotlin/io/spine/logging/given/LoggingRateForecasting.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/given/LoggingRateForecasting.kt
@@ -50,6 +50,23 @@ internal fun expectedRuns(invocations: Int, invocationRateLimit: Int): Int {
 }
 
 /**
+ * Calculates how many times a logging statement should be executed for each
+ * enum value when the execution rate is limited by [LoggingApi.every] method.
+ *
+ * @param invocations
+ *          number of times a logging statement is invoked for each enum value
+ * @param invocationRateLimit
+ *          the configured rate limitation
+ */
+@Suppress("SameParameterValue") // Extracted to a method for better readability.
+internal fun expectedRuns(
+    invocations: Map<Task, Int>,
+    invocationRateLimit: Int,
+): Map<Task, Int> = invocations.mapValues { entry ->
+    expectedRuns(entry.value, invocationRateLimit)
+}
+
+/**
  * Calculates how many times a logging statement should be executed when
  * its execution rate is limited by [LoggingApi.atMostEvery] method.
  *

--- a/logging/src/jvmTest/kotlin/io/spine/logging/given/Task.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/given/Task.kt
@@ -29,4 +29,7 @@ package io.spine.logging.given
 internal enum class Task {
     BUILD,
     DESTROY,
+    REVISE,
+    UPDATE,
+    ARCHIVE
 }

--- a/logging/src/jvmTest/kotlin/io/spine/logging/given/Task.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/given/Task.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging.given
+
+internal enum class Task {
+    BUILD,
+    DESTROY,
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.188</version>
+<version>2.0.0-SNAPSHOT.189</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.188")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.189")


### PR DESCRIPTION
This PR adds `per(...)` method to `LoggingApi`. 

It allows restricting conditional behavior (e.g., rate limiting) with an additional qualifier: enum value. It is useful in helping to avoid cases where a rare event might never be logged due to rate limiting.

For example, the following code will cause log statements with different  `taskType`s to be rate-limited independently of each other:

```
// We want to rate limit logging separately for each task type.
logger.at(INFO)
    .per(task.type)
    .atMostEvery(30, SECONDS)
    .log("Start task: %s", task.name);
 ```

Its JVM implementation is delegated to Flogger. 