### PR TITLE
Enhance API for Java clients

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -756,12 +756,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:34 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -850,12 +850,12 @@ This report was generated on **Mon Aug 07 11:49:34 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:35 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-api-tests:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-api-tests:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1612,12 +1612,12 @@ This report was generated on **Mon Aug 07 11:49:35 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -1701,12 +1701,12 @@ This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1847,12 +1847,12 @@ This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
@@ -1869,12 +1869,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -1975,12 +1975,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -2101,12 +2101,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2875,12 +2875,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:38 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:43 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3645,12 +3645,12 @@ This report was generated on **Mon Aug 07 11:49:38 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4411,12 +4411,12 @@ This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5189,12 +5189,12 @@ This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:40 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5971,12 +5971,12 @@ This report was generated on **Mon Aug 07 11:49:40 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:48 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6705,12 +6705,12 @@ This report was generated on **Mon Aug 07 11:49:41 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:43 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:49 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7474,12 +7474,12 @@ This report was generated on **Mon Aug 07 11:49:43 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:50 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8243,12 +8243,12 @@ This report was generated on **Mon Aug 07 11:49:44 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:50 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9066,4 +9066,4 @@ This report was generated on **Mon Aug 07 11:49:45 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 15:12:51 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/logging/src/jvmMain/java/io/spine/logging/LazyStringFormat.java
+++ b/logging/src/jvmMain/java/io/spine/logging/LazyStringFormat.java
@@ -1,0 +1,31 @@
+package io.spine.logging;
+
+import kotlin.jvm.functions.Function0;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
+
+/**
+ * Provides a utility method to simplify passing formatted strings
+ * to {@linkplain LoggingApi#log(Function0) loggers}.
+ */
+public final class LazyStringFormat {
+
+    /**
+     * Prevents instantiation of this utility class.
+     */
+    private LazyStringFormat() {
+    }
+
+    /**
+     * Returns a string supplier with a formatted string.
+     *
+     * <p>The formatter uses {@link Locale#ENGLISH ENGLISH} locale.
+     *
+     * @see String#format(String, Object...)
+     */
+    public static Function0<String> lazyFormat(String format, Object... args) {
+        return () -> format(Locale.ENGLISH, format, args);
+    }
+}

--- a/logging/src/jvmTest/java/io/spine/logging/JavaWithLoggingTest.java
+++ b/logging/src/jvmTest/java/io/spine/logging/JavaWithLoggingTest.java
@@ -51,6 +51,8 @@ class JavaWithLoggingTest {
     }
 
     private static class LoggingClass implements WithLogging {
+
+        @SuppressWarnings("SameParameterValue") // Avoid usage of outer class' private members.
         private void myMethod(String message) {
             logger().atWarning().log(() -> message);
         }

--- a/logging/src/jvmTest/java/io/spine/logging/LazyStringFormatTest.java
+++ b/logging/src/jvmTest/java/io/spine/logging/LazyStringFormatTest.java
@@ -24,28 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.logging
+package io.spine.logging;
 
-import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
+import kotlin.Unit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-@DisplayName("`JvmWithLogging` interface should")
-internal class JvmWithLoggingSpec {
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.logging.LazyStringFormat.lazyFormat;
+
+@DisplayName("`LazyStringFormatTest` should")
+class LazyStringFormatTest {
 
     @Test
-    fun `provide 'JvmLogger' for hard class`() {
-        class LoggingClass : WithLogging
-        val instance = LoggingClass()
-        val usedLogger = instance.logger
-        usedLogger::class shouldBe JvmLogger::class
+    @DisplayName("provide a shortcut for `String.format()`")
+    void provideShortcutToStringFormat() {
+        var number = 123321;
+        var expectedMsg = "Integer: " + number;
+        var loggingInstance = new LoggingClass();
+        var output = TapConsoleKt.tapConsole(() -> {
+            loggingInstance.myMethod("Integer: %d", number);
+            return Unit.INSTANCE;
+        });
+
+        assertThat(output).contains(expectedMsg);
+        assertThat(output).contains(LazyStringFormatTest.LoggingClass.class.getSimpleName());
     }
 
-    @Test
-    fun `provide 'JvmLogger' for local objects`() {
-        val loggingObject = object : WithLogging { }
-        val usedLogger = loggingObject.logger
-        usedLogger::class shouldBe JvmLogger::class
+    private static class LoggingClass implements WithLogging {
+
+        @SuppressWarnings("SameParameterValue") // It is better to pass parameters explicitly.
+        private void myMethod(String format, Object... args) {
+            logger().atWarning().log(lazyFormat(format, args));
+        }
     }
 }
-

--- a/logging/src/jvmTest/java/io/spine/logging/given/Base.java
+++ b/logging/src/jvmTest/java/io/spine/logging/given/Base.java
@@ -31,5 +31,6 @@ import io.spine.logging.Logging;
 /**
  * The root of the class hierarchy.
  */
+@SuppressWarnings("removal")
 public class Base implements Logging {
 }

--- a/logging/src/jvmTest/java/io/spine/logging/given/LoggingObject.java
+++ b/logging/src/jvmTest/java/io/spine/logging/given/LoggingObject.java
@@ -31,5 +31,6 @@ import io.spine.logging.Logging;
 /**
  * A test dummy class which implements the {@link Logging} interface.
  */
+@SuppressWarnings("removal")
 public final class LoggingObject implements Logging {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.199</version>
+<version>2.0.0-SNAPSHOT.200</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/logging-smoke-test/src/main/kotlin/io/spine/logging/AbstractLoggingSmokeTest.kt
+++ b/tests/logging-smoke-test/src/main/kotlin/io/spine/logging/AbstractLoggingSmokeTest.kt
@@ -111,6 +111,7 @@ public abstract class AbstractLoggingSmokeTest {
     }
 }
 
+@Suppress("DEPRECATION", "removal")
 private class LoggingClass : Logging {
     fun logSomething(msg: String) {
         _info().log(msg)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.199")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.200")


### PR DESCRIPTION
This PR proposes `lazyFmt(...)` shortcut for logging statements with formatted strings in Java.

Usage example:

```java
// Now:
logger().atWarning().log(() -> format("format string", arg1, arg2, ...));

// Suggested usage:
logger().atWarning().log(lazyFmt("format string", arg1, arg2, ...));
```

It is a separate static method, that returns an analogue of `Supplier<String>`, applicable in Kotlin. It is a bit shorter, compared to a full lambda definition. But clients now need to know about existence of this static method. 

Please note, this call is not lazy. Arguments will be calculated when `.lazyFmt()` is called.