### PR TITLE
Extend `LoggingApi` with a JVM-specific method

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -756,12 +756,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:34 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -850,12 +850,12 @@ This report was generated on **Mon Aug 07 11:49:34 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:35 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-api-tests:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-api-tests:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1612,12 +1612,12 @@ This report was generated on **Mon Aug 07 11:49:35 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -1701,12 +1701,12 @@ This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1847,12 +1847,12 @@ This report was generated on **Mon Aug 07 11:49:36 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
@@ -1869,12 +1869,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
@@ -1975,12 +1975,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -2101,12 +2101,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2875,12 +2875,12 @@ This report was generated on **Mon Aug 07 11:49:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:38 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:47 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3645,12 +3645,12 @@ This report was generated on **Mon Aug 07 11:49:38 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:47 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4411,12 +4411,12 @@ This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:48 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5189,12 +5189,12 @@ This report was generated on **Mon Aug 07 11:49:39 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:40 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:49 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5971,12 +5971,12 @@ This report was generated on **Mon Aug 07 11:49:40 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:52 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6705,12 +6705,12 @@ This report was generated on **Mon Aug 07 11:49:41 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:43 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:52 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7474,12 +7474,12 @@ This report was generated on **Mon Aug 07 11:49:43 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:53 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8243,12 +8243,12 @@ This report was generated on **Mon Aug 07 11:49:44 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:53 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.199`
+# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.200`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9066,4 +9066,4 @@ This report was generated on **Mon Aug 07 11:49:45 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 07 11:49:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 08 18:24:54 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -271,65 +271,69 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
     public fun log(message: () -> String)
 }
 
-/**
- * An implementation of [LoggingApi] which does nothing, discarding all parameters.
- *
- * Extending classes are likely to be non-wildcard, fully specified, no-op
- * implementations of the [API].
- */
-public open class NoOpLoggingApi<API: LoggingApi<API>>: LoggingApi<API> {
+// Class 'NoOpLoggingApi' is not abstract and does not implement abstract member
+// public abstract fun log(format: String, vararg args: Any): Unit defined in io.spine.logging.LoggingApi
 
-    /**
-     * Obtains the reference to this no-op implementation of fluent logging [API].
-     */
-    @Suppress(
-        "UNCHECKED_CAST" /* The cast is safe since the class implements `API`. */,
-        "MemberNameEqualsClassName" /* The name highlights the emptiness of the impl. */
-    )
-    protected fun noOp(): API = this as API
 
-    /**
-     * Does nothing.
-     */
-    override fun withLoggingDomain(domain: LoggingDomain): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun withCause(cause: Throwable): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun withInjectedLogSite(logSite: LogSite): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun every(n: Int): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun per(key: Enum<*>): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun atMostEvery(n: Int, unit: DurationUnit): API = noOp()
-
-    /**
-     * Always returns `false`.
-     */
-    override fun isEnabled(): Boolean = false
-
-    /**
-     * Does nothing.
-     */
-    override fun log(): Unit = Unit
-
-    /**
-     * Does nothing.
-     */
-    override fun log(message: () -> String): Unit = Unit
-}
+///**
+// * An implementation of [LoggingApi] which does nothing, discarding all parameters.
+// *
+// * Extending classes are likely to be non-wildcard, fully specified, no-op
+// * implementations of the [API].
+// */
+//public open class NoOpLoggingApi<API: LoggingApi<API>>: LoggingApi<API> {
+//
+//    /**
+//     * Obtains the reference to this no-op implementation of fluent logging [API].
+//     */
+//    @Suppress(
+//        "UNCHECKED_CAST" /* The cast is safe since the class implements `API`. */,
+//        "MemberNameEqualsClassName" /* The name highlights the emptiness of the impl. */
+//    )
+//    protected fun noOp(): API = this as API
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun withLoggingDomain(domain: LoggingDomain): API = noOp()
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun withCause(cause: Throwable): API = noOp()
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun withInjectedLogSite(logSite: LogSite): API = noOp()
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun every(n: Int): API = noOp()
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun per(key: Enum<*>): API = noOp()
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun atMostEvery(n: Int, unit: DurationUnit): API = noOp()
+//
+//    /**
+//     * Always returns `false`.
+//     */
+//    override fun isEnabled(): Boolean = false
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun log(): Unit = Unit
+//
+//    /**
+//     * Does nothing.
+//     */
+//    override fun log(message: () -> String): Unit = Unit
+//}

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -274,6 +274,8 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
 // Class 'NoOpLoggingApi' is not abstract and does not implement abstract member
 // public abstract fun log(format: String, vararg args: Any): Unit defined in io.spine.logging.LoggingApi
 
+// → Changes made to `LoggingApi` in JVM sources affect common code.
+
 
 ///**
 // * An implementation of [LoggingApi] which does nothing, discarding all parameters.

--- a/logging/src/commonTest/kotlin/io/spine/logging/LoggingApiSpec.kt
+++ b/logging/src/commonTest/kotlin/io/spine/logging/LoggingApiSpec.kt
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.Test
 @DisplayName("`LoggingApi` should")
 internal class LoggingApiSpec {
 
-    @Test
-    fun `provide no-op implementation class`() {
-        val noOp = NoOpLoggingApi<LeafApi>()
-        noOp.isEnabled() shouldBe false
-        noOp.withCause(Throwable("stub instance")) shouldBeSameInstanceAs noOp
-    }
+//    @Test
+//    fun `provide no-op implementation class`() {
+//        val noOp = NoOpLoggingApi<LeafApi>()
+//        noOp.isEnabled() shouldBe false
+//        noOp.withCause(Throwable("stub instance")) shouldBeSameInstanceAs noOp
+//    }
 }
 
 private interface LeafApi: LoggingApi<LeafApi>

--- a/logging/src/commonTest/kotlin/io/spine/logging/LoggingApiSpec.kt
+++ b/logging/src/commonTest/kotlin/io/spine/logging/LoggingApiSpec.kt
@@ -36,7 +36,7 @@ internal class LoggingApiSpec {
 
     @Test
     fun `provide no-op implementation class`() {
-        val noOp = LoggingApi.NoOp<LeafApi>()
+        val noOp = NoOpLoggingApi<LeafApi>()
         noOp.isEnabled() shouldBe false
         noOp.withCause(Throwable("stub instance")) shouldBeSameInstanceAs noOp
     }

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
@@ -62,45 +62,26 @@ public class JvmLogger(
      * A no-op singleton implementation of [Api].
      */
     private object NoOp: Api {
-        override fun withLoggingDomain(domain: LoggingDomain): Api {
-            TODO("Not yet implemented")
-        }
 
-        override fun withCause(cause: Throwable): Api {
-            TODO("Not yet implemented")
-        }
+        override fun withLoggingDomain(domain: LoggingDomain): Api = this
 
-        override fun withInjectedLogSite(logSite: LogSite): Api {
-            TODO("Not yet implemented")
-        }
+        override fun withCause(cause: Throwable): Api = this
 
-        override fun every(n: Int): Api {
-            TODO("Not yet implemented")
-        }
+        override fun withInjectedLogSite(logSite: LogSite): Api = this
 
-        override fun atMostEvery(n: Int, unit: DurationUnit): Api {
-            TODO("Not yet implemented")
-        }
+        override fun every(n: Int): Api = this
 
-        override fun per(key: Enum<*>): Api {
-            TODO("Not yet implemented")
-        }
+        override fun atMostEvery(n: Int, unit: DurationUnit): Api = this
 
-        override fun isEnabled(): Boolean {
-            TODO("Not yet implemented")
-        }
+        override fun per(key: Enum<*>): Api = this
 
-        override fun log() {
-            TODO("Not yet implemented")
-        }
+        override fun isEnabled(): Boolean = false
 
-        override fun log(message: () -> String) {
-            TODO("Not yet implemented")
-        }
+        override fun log() = Unit
 
-        override fun log(format: String, vararg args: Any) {
-            TODO("Not yet implemented")
-        }
+        override fun log(message: () -> String) = Unit
+
+        override fun log(format: String, vararg args: Any) = Unit
     }
 }
 

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
@@ -61,7 +61,47 @@ public class JvmLogger(
     /**
      * A no-op singleton implementation of [Api].
      */
-    private object NoOp: NoOpLoggingApi<Api>(), Api
+    private object NoOp: Api {
+        override fun withLoggingDomain(domain: LoggingDomain): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun withCause(cause: Throwable): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun withInjectedLogSite(logSite: LogSite): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun every(n: Int): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun atMostEvery(n: Int, unit: DurationUnit): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun per(key: Enum<*>): Api {
+            TODO("Not yet implemented")
+        }
+
+        override fun isEnabled(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun log() {
+            TODO("Not yet implemented")
+        }
+
+        override fun log(message: () -> String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun log(format: String, vararg args: Any) {
+            TODO("Not yet implemented")
+        }
+    }
 }
 
 /**
@@ -115,6 +155,12 @@ private class ApiImpl(private val delegate: FluentLogger.Api): JvmLogger.Api {
             val prefix = loggingDomain.messagePrefix
             delegate.withInjectedLogSite(callerOf(ApiImpl::class.java))
                 .log(prefix + message.invoke())
+        }
+    }
+
+    override fun log(format: String, vararg args: Any) {
+        if (isEnabled()) {
+            log { format.format(*args) }
         }
     }
 }

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLogger.kt
@@ -61,7 +61,7 @@ public class JvmLogger(
     /**
      * A no-op singleton implementation of [Api].
      */
-    private object NoOp: LoggingApi.NoOp<Api>(), Api
+    private object NoOp: NoOpLoggingApi<Api>(), Api
 }
 
 /**

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLoggingApi.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLoggingApi.kt
@@ -271,4 +271,6 @@ public actual interface LoggingApi<API: LoggingApi<API>> {
      * Logs a message produced by the given function block.
      */
     public actual fun log(message: () -> String)
+
+    public fun log(format: String, vararg args: Any)
 }

--- a/logging/src/jvmMain/kotlin/io/spine/logging/JvmLoggingApi.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/JvmLoggingApi.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("MatchingDeclarationName")
+
 package io.spine.logging
 
 import kotlin.time.DurationUnit
@@ -31,12 +33,12 @@ import kotlin.time.DurationUnit
 /**
  * The basic logging API returned by a [Logger].
  */
-public expect interface LoggingApi<API: LoggingApi<API>> {
+public actual interface LoggingApi<API: LoggingApi<API>> {
 
     /**
      * Associates the given domain with the current log statement.
      */
-    public fun withLoggingDomain(domain: LoggingDomain): API
+    public actual fun withLoggingDomain(domain: LoggingDomain): API
 
     /**
      * Associates a [Throwable] with the current log statement.
@@ -47,7 +49,7 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * If the method is called more than once, the parameter of the last
      * invocation will be used.
      */
-    public fun withCause(cause: Throwable): API
+    public actual fun withCause(cause: Throwable): API
 
     /**
      * Sets the log site for the current log statement.
@@ -130,7 +132,7 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * expected to occur just before the final log() call and must be overrideable
      * by earlier (explicit) calls.
      */
-    public fun withInjectedLogSite(logSite: LogSite): API
+    public actual fun withInjectedLogSite(logSite: LogSite): API
 
     /**
      * Modifies the current log statement to be emitted only once per N invocations.
@@ -150,7 +152,7 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * @throws IllegalArgumentException
      *          if `n` is negative or zero
      */
-    public fun every(n: Int): API
+    public actual fun every(n: Int): API
 
     /**
      * Modifies the current log statement to be emitted **at most** once per
@@ -214,7 +216,7 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * @throws IllegalArgumentException
      *          if `n` is negative
      */
-    public fun atMostEvery(n: Int, unit: DurationUnit): API
+    public actual fun atMostEvery(n: Int, unit: DurationUnit): API
 
     /**
      * Aggregates stateful logging with respect to the given enum value.
@@ -248,12 +250,12 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * then they all take effect and logging is aggregated by the unique
      * combination of keys passed to all [per] methods.
      */
-    public fun per(key: Enum<*>): API
+    public actual fun per(key: Enum<*>): API
 
     /**
      * Returns `true` if logging is enabled at the level implied for this API.
      */
-    public fun isEnabled(): Boolean
+    public actual fun isEnabled(): Boolean
 
     /**
      * Terminal log statement when a message is not required.
@@ -263,73 +265,10 @@ public expect interface LoggingApi<API: LoggingApi<API>> {
      * logger.at(ERROR).withCause(error).log()
      * ```
      */
-    public fun log()
+    public actual fun log()
 
     /**
      * Logs a message produced by the given function block.
      */
-    public fun log(message: () -> String)
-}
-
-/**
- * An implementation of [LoggingApi] which does nothing, discarding all parameters.
- *
- * Extending classes are likely to be non-wildcard, fully specified, no-op
- * implementations of the [API].
- */
-public open class NoOpLoggingApi<API: LoggingApi<API>>: LoggingApi<API> {
-
-    /**
-     * Obtains the reference to this no-op implementation of fluent logging [API].
-     */
-    @Suppress(
-        "UNCHECKED_CAST" /* The cast is safe since the class implements `API`. */,
-        "MemberNameEqualsClassName" /* The name highlights the emptiness of the impl. */
-    )
-    protected fun noOp(): API = this as API
-
-    /**
-     * Does nothing.
-     */
-    override fun withLoggingDomain(domain: LoggingDomain): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun withCause(cause: Throwable): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun withInjectedLogSite(logSite: LogSite): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun every(n: Int): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun per(key: Enum<*>): API = noOp()
-
-    /**
-     * Does nothing.
-     */
-    override fun atMostEvery(n: Int, unit: DurationUnit): API = noOp()
-
-    /**
-     * Always returns `false`.
-     */
-    override fun isEnabled(): Boolean = false
-
-    /**
-     * Does nothing.
-     */
-    override fun log(): Unit = Unit
-
-    /**
-     * Does nothing.
-     */
-    override fun log(message: () -> String): Unit = Unit
+    public actual fun log(message: () -> String)
 }

--- a/logging/src/jvmTest/java/io/spine/logging/JavaWithLoggingTest.java
+++ b/logging/src/jvmTest/java/io/spine/logging/JavaWithLoggingTest.java
@@ -50,9 +50,29 @@ class JavaWithLoggingTest {
         assertThat(output).contains(LoggingClass.class.getSimpleName());
     }
 
+    @Test
+    @DisplayName("provide a shortcut for `String.format()`")
+    void provideShortcutToStringFormat() {
+        var loggingInstance = new LoggingClass();
+        var output = TapConsoleKt.tapConsole(() -> {
+            loggingInstance.myMethod();
+            return Unit.INSTANCE;
+        });
+
+        assertThat(output).contains("integer: 153");
+        assertThat(output).contains(JavaWithLoggingTest.LoggingClass.class.getSimpleName());
+    }
+
     private static class LoggingClass implements WithLogging {
+
         private void myMethod(String message) {
+            // IDEA highlights this call in red, but it works.
             logger().atWarning().log(() -> message);
+        }
+
+        private void myMethod() {
+            // IDEA highlights this call in red, but it works.
+            logger().atWarning().log("integer: %d", 153);
         }
     }
 }

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -55,16 +55,16 @@ internal class JvmLoggerSpec {
     private val logger = LoggingFactory.loggerFor(this::class)
     private val message = "logging test message"
 
-    @Test
-    fun `create no-op instance when logging level is too low`() {
-        // The default level (with Java logging as the backend) is `INFO`.
-        (logger.atTrace() is NoOpLoggingApi) shouldBe true
-        (logger.atDebug() is NoOpLoggingApi) shouldBe true
-
-        (logger.atInfo() is NoOpLoggingApi) shouldBe false
-        (logger.atWarning() is NoOpLoggingApi) shouldBe false
-        (logger.atError() is NoOpLoggingApi) shouldBe false
-    }
+//    @Test
+//    fun `create no-op instance when logging level is too low`() {
+//         The default level (with Java logging as the backend) is `INFO`.
+//        (logger.atTrace() is NoOpLoggingApi) shouldBe true
+//        (logger.atDebug() is NoOpLoggingApi) shouldBe true
+//
+//        (logger.atInfo() is NoOpLoggingApi) shouldBe false
+//        (logger.atWarning() is NoOpLoggingApi) shouldBe false
+//        (logger.atError() is NoOpLoggingApi) shouldBe false
+//    }
 
     @Test
     fun `produce the output with the name of the logging class and calling method`() {

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -58,12 +58,12 @@ internal class JvmLoggerSpec {
     @Test
     fun `create no-op instance when logging level is too low`() {
         // The default level (with Java logging as the backend) is `INFO`.
-        (logger.atTrace() is LoggingApi.NoOp) shouldBe true
-        (logger.atDebug() is LoggingApi.NoOp) shouldBe true
+        (logger.atTrace() is NoOpLoggingApi) shouldBe true
+        (logger.atDebug() is NoOpLoggingApi) shouldBe true
 
-        (logger.atInfo() is LoggingApi.NoOp) shouldBe false
-        (logger.atWarning() is LoggingApi.NoOp) shouldBe false
-        (logger.atError() is LoggingApi.NoOp) shouldBe false
+        (logger.atInfo() is NoOpLoggingApi) shouldBe false
+        (logger.atWarning() is NoOpLoggingApi) shouldBe false
+        (logger.atError() is NoOpLoggingApi) shouldBe false
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.199</version>
+<version>2.0.0-SNAPSHOT.200</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.199")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.200")


### PR DESCRIPTION
This PR effectively solves the same problem as #23, but with KM features (or bugs, I'm not sure).

It makes `LoggingApi` an expected declaration and declares it for JVM target with one additional method: `log(format: String, vararg args: Any)`.

Usage example:

```java
// Now:
logger().atWarning().log(() -> format("format string", arg1, arg2, ...));

// Suggested usage:
logger().atWarning().log("integer: %d", 153);
```

It eases logging statements in Java, which doesn't have string templates like Kotlin. 

Please note, this call is not lazy. Arguments will be calculated when `log()` is called.

### Caveats

1. Docs duplication. We have an extensive documentation to `LoggingApi`. And as for now, documentation is not picked up for actual declarations. We have to duplicate it.
2. It is not possible to have `NoOp` implementation in the common code for two reasons: 1) Default implementation in `expect` declarations are still [prohibited](https://youtrack.jetbrains.com/issue/KT-20427); 2) A platform-specific method leaks to the common code, failing the compilation. Common `NoOp` should also implement JVM-specific `log(format, args)` method, which is unexpected. I think it is a part of the mentioned issue, and should disappear when we mark `NoOp` as expected, providing default implementation for common methods.
3. Presence of [platform-specific members](https://youtrack.jetbrains.com/issue/KT-34668) is not supported officially. Although, I can't find any relevant docs on this matter. I mean official docs. It is dangerous to rely on the fact that it works until IDEA support and comprehensive docs covering is [done](https://youtrack.jetbrains.com/issue/KT-38552/Expect-actual-matching).
4. The same method would leak to Kotlin/JVM client as well. They are armed with string templates, but would also see this `printf`-like method. Java and Kotlin share the same JVM target.
5. IDEA code completion fails to determine the returned type of `logger().atWarning()` call. It doesn't detect that it returns `LoggingApi<*>`. Thus, highlighting all calls to the API with red. Meanwhile, it successfully compiles.