### PR TITLE
Make logging factory provide a logger for the enclosing class

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-fixtures:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -510,10 +510,6 @@
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
-     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
@@ -522,21 +518,21 @@
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.10.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.10.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.10.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.10.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 23.0.0.
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : coverage-report. **Version** : 1.0.21.
-     * **Project URL:** [https://github.com/JetBrains/coverage-report](https://github.com/JetBrains/coverage-report)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.724.
-     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-reporter. **Version** : 1.0.724.
-     * **Project URL:** [https://github.com/JetBrains/intellij-coverage](https://github.com/JetBrains/intellij-coverage)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
@@ -680,6 +676,16 @@
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.5.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.5.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
      * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -687,12 +693,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:34 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:12 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-api:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1457,12 +1463,12 @@ This report was generated on **Thu Aug 24 13:46:34 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:13 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-grpc-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1648,12 +1654,12 @@ This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:13 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-log4j2-backend:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1884,12 +1890,12 @@ This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:13 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-platform-generator:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
@@ -1906,12 +1912,12 @@ This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:13 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-system-backend:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2114,12 +2120,12 @@ This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:14 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-flogger-testing:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -2330,12 +2336,12 @@ This report was generated on **Thu Aug 24 13:46:37 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:38 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:14 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-jvm-log4j-backend-our-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3112,12 +3118,12 @@ This report was generated on **Thu Aug 24 13:46:38 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:38 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:16 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-jvm-our-backend-grpc-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3890,12 +3896,12 @@ This report was generated on **Thu Aug 24 13:46:38 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:39 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:17 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-jvm-our-backend-our-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4664,12 +4670,12 @@ This report was generated on **Thu Aug 24 13:46:39 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:40 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:18 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-jvm-slf4j-jdk14-backend-our-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5450,12 +5456,12 @@ This report was generated on **Thu Aug 24 13:46:40 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:41 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:19 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-jvm-slf4j-reload4j-backend-our-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6240,12 +6246,12 @@ This report was generated on **Thu Aug 24 13:46:41 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:42 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:20 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6903,12 +6909,12 @@ This report was generated on **Thu Aug 24 13:46:42 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:43 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:21 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-logging-backend:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7681,12 +7687,12 @@ This report was generated on **Thu Aug 24 13:46:43 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:21 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-logging-context:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8455,12 +8461,12 @@ This report was generated on **Thu Aug 24 13:46:44 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:44 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:22 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9283,12 +9289,12 @@ This report was generated on **Thu Aug 24 13:46:44 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:45 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:23 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-testutil:2.0.0-SNAPSHOT.208`
+# Dependencies of `io.spine:spine-logging-testutil:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10053,4 +10059,4 @@ This report was generated on **Thu Aug 24 13:46:45 EEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 24 13:46:46 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 24 16:57:24 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingFactory.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingFactory.kt
@@ -34,6 +34,13 @@ import kotlin.reflect.KClass
 public expect object LoggingFactory {
 
     /**
+     * Obtains the logger for the enclosing class.
+     *
+     * Implementation should provide the same logger instance for the same class.
+     */
+    public fun <API: LoggingApi<API>> forEnclosingClass(): Logger<API>
+
+    /**
      * Obtains the logger for the given class.
      *
      * Implementation should provide the same logger instance for the same class.

--- a/logging/src/jvmMain/kotlin/io/spine/logging/LoggingFactory.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/LoggingFactory.kt
@@ -96,4 +96,9 @@ public actual object LoggingFactory: ClassValue<JvmLogger>() {
         val backend = Platform.getBackend(cls.name)
         return FluentLogger2(backend)
     }
+
+    @JvmStatic
+    public actual fun <API : LoggingApi<API>> forEnclosingClass(): Logger<API> {
+        return loggerFor(this::class)
+    }
 }

--- a/logging/src/jvmMain/kotlin/io/spine/logging/LoggingFactory.kt
+++ b/logging/src/jvmMain/kotlin/io/spine/logging/LoggingFactory.kt
@@ -88,13 +88,10 @@ public actual object LoggingFactory: ClassValue<JvmLogger>() {
     }
 
     private fun createForClass(cls: Class<*>): JvmLogger {
-        val impl = createFluentLogger(cls)
-        return JvmLogger(cls.kotlin, impl)
-    }
-
-    private fun createFluentLogger(cls: Class<*>): FluentLogger2 {
-        val backend = Platform.getBackend(cls.name)
-        return FluentLogger2(backend)
+        val floggerBackend = Platform.getBackend(cls.name)
+        val flogger = FluentLogger2(floggerBackend)
+        // As for now, `JvmLogger` just delegates actual work to Flogger.
+        return JvmLogger(cls.kotlin, flogger)
     }
 
     @JvmStatic

--- a/logging/src/jvmTest/java/io/spine/logging/JavaLoggingFactoryTest.java
+++ b/logging/src/jvmTest/java/io/spine/logging/JavaLoggingFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging;
+
+import io.spine.logging.given.LoggingUtility;
+import kotlin.Unit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.logging.testutil.TapConsoleKt.tapConsole;
+
+@DisplayName("In Java, `LoggingFactory` should")
+class JavaLoggingFactoryTest {
+
+    @Test
+    @DisplayName("provide a logger for enclosing class from a static context")
+    void provideLoggerForEnclosingClassFromStaticContext() {
+        var message = "expected message";
+        var output = tapConsole(() -> {
+            LoggingUtility.logFromStaticMethod(message);
+            return Unit.INSTANCE;
+        });
+        var utilityName = LoggingUtility.class.getSimpleName();
+        var testClassName = getClass().getSimpleName();
+        assertThat(output).contains(utilityName);
+        assertThat(output).contains(message);
+        assertThat(output).doesNotContain(testClassName);
+    }
+}

--- a/logging/src/jvmTest/java/io/spine/logging/given/LoggingUtility.java
+++ b/logging/src/jvmTest/java/io/spine/logging/given/LoggingUtility.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging.given;
+
+import io.spine.logging.Logger;
+import io.spine.logging.LoggingFactory;
+
+/**
+ * A test dummy utility class that gets a logger using
+ * {@link LoggingFactory#forEnclosingClass() LoggingFactory.forEnclosingClass()}.
+ */
+public final class LoggingUtility {
+
+    private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
+
+    /**
+     * Prevents instantiation of this utility class.
+     */
+    private LoggingUtility() {
+    }
+
+    /**
+     * Logs the given message on behalf of this utility.
+     */
+    public static void logFromStaticMethod(String message) {
+        logger.atInfo().log(() -> message);
+    }
+}

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggerSpec.kt
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.assertThrows
 @DisplayName("`JvmLogger` should")
 internal class JvmLoggerSpec {
 
-    private val logger = LoggingFactory.loggerFor(this::class)
+    private val logger = LoggingFactory.forEnclosingClass()
     private val message = "logging test message"
 
     @Test

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("`JvmLoggerFactory` should")
-internal class JvmLoggerFactorySpec {
+@DisplayName("`JvmLoggingFactory` should")
+internal class JvmLoggingFactorySpec {
 
     @Nested
     inner class `obtain a logging domain for` {

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
@@ -27,16 +27,37 @@
 package io.spine.logging
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.spine.logging.LoggingFactory.loggingDomainOf
 import io.spine.logging.given.domain.AnnotatedClass
 import io.spine.logging.given.domain.IndirectlyAnnotatedClass
 import io.spine.logging.given.domain.nested.NonAnnotatedNestedPackageClass
+import io.spine.logging.testutil.tapConsole
+import kotlin.reflect.jvm.jvmName
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("`JvmLoggingFactory` should")
 internal class JvmLoggingFactorySpec {
+
+    @Test
+    fun `provide a logger for enclosing class`() {
+        val logger = LoggingFactory.forEnclosingClass()
+        val message = "expected message"
+        val output = tapConsole {
+            logger.atInfo().log { message }
+        }
+        output shouldContain this::class.jvmName
+    }
+
+    @Test
+    fun `provide the same logger for the same enclosing class`() {
+        val firstLogger = LoggingFactory.forEnclosingClass()
+        val secondLogger = LoggingFactory.forEnclosingClass()
+        firstLogger shouldBeSameInstanceAs secondLogger
+    }
 
     @Nested
     inner class `obtain a logging domain for` {

--- a/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
+++ b/logging/src/jvmTest/kotlin/io/spine/logging/JvmLoggingFactorySpec.kt
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test
 internal class JvmLoggingFactorySpec {
 
     @Test
-    fun `provide a logger for enclosing class`() {
+    fun `provide a logger for the enclosing class`() {
         val logger = LoggingFactory.forEnclosingClass()
         val message = "expected message"
         val output = tapConsole {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.208</version>
+<version>2.0.0-SNAPSHOT.209</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -289,16 +289,6 @@ all modules and does not describe the project structure per-subproject.
     <groupId>org.jetbrains.dokka</groupId>
     <artifactId>kotlin-as-java-plugin</artifactId>
     <version>1.8.10</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.intellij.deps</groupId>
-    <artifactId>intellij-coverage-agent</artifactId>
-    <version>1.0.724</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.intellij.deps</groupId>
-    <artifactId>intellij-coverage-reporter</artifactId>
-    <version>1.0.724</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.208")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.209")


### PR DESCRIPTION
This PR addresses #33 and #7.

It extends `LoggingFactory` with `forEnclosingClass()` method. This method will also be accessible in Java from a static context.

Additional changes:

1. `private createFluentLogger()` method was merged with `private createForClass()` method. Detekt reported too many methods in `LoggingFactory`. 
2. `JvmLoggerFacrorySpec` has been renamed to `JvmLoggingFactorySpec` to match the test subject (`LoggingFactory`).