### PR TITLE
Allow turning logging off via `LogLevelMap`

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,11 +3,7 @@
   <component name="Kotlin2JvmCompilerArguments">
     <option name="jvmTarget" value="11" />
   </component>
-  <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.9.22" />
-    <option name="languageVersion" value="1.9.22" />
-  </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.22" />
+    <option name="version" value="1.9.24" />
   </component>
 </project>

--- a/backends/log4j2-backend/src/main/java/io/spine/logging/backend/log4j2/Log4j2BackendFactory.java
+++ b/backends/log4j2-backend/src/main/java/io/spine/logging/backend/log4j2/Log4j2BackendFactory.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.core.Logger;
 /**
  * Backend factory for Log4j2.
  *
- * <p>When using {@link io.spine.logging.backend.system.DefaultPlatform DefaultPlatform},
+ * <p>When using {@code io.spine.logging.backend.system.DefaultPlatform},
  * this factory will automatically be used if it is included on the classpath,
  * and no other implementation of {@code BackendFactory} (other than the default
  * implementation) is present.

--- a/backends/probe-backend/src/main/kotlin/io/spine/logging/backend/probe/DynamicBackendFactory.kt
+++ b/backends/probe-backend/src/main/kotlin/io/spine/logging/backend/probe/DynamicBackendFactory.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -31,7 +31,7 @@ import io.spine.logging.flogger.backend.BackendFactory
 import io.spine.logging.backend.jul.JulBackendFactory
 
 /**
- * A factory that delegates backends creation to another factory,
+ * A factory that delegates backends creation to another factory
  * and allows changing of the underlying factory in runtime.
  *
  * In general, the logging facade doesn't provide a mechanism for changing
@@ -76,7 +76,7 @@ public object DynamicBackendFactory : BackendFactory() {
         delegate?.create(loggingClassName) ?: julBackends.create(loggingClassName)
 
     /**
-     * Returns a fully-qualified name of this class.
+     * Returns a fully qualified name of this class.
      */
     override fun toString(): String = javaClass.name
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -126,7 +126,7 @@ val detektVersion = "1.23.0"
 /**
  * @see [io.spine.internal.dependency.Kotest]
  */
-val kotestJvmPluginVersion = "0.4.10"
+val kotestJvmPluginVersion = "0.4.11"
 
 /**
  * @see [io.spine.internal.dependency.Kotest.MultiplatformGradlePlugin]

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
@@ -53,7 +53,7 @@ object Kotest {
 
     // https://github.com/kotest/kotest-gradle-plugin
     object JvmGradlePlugin {
-        const val version = "0.4.10"
+        const val version = "0.4.11"
         const val id = "io.kotest"
         const val classpath = "$group:kotest-gradle-plugin:$version"
     }

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -184,9 +184,7 @@ fun Module.setupTests() {
     tasks {
         registerTestTasks()
         test.configure {
-            useJUnitPlatform {
-                includeEngines("junit-jupiter")
-            }
+            useJUnitPlatform()
             configureLogging()
         }
     }

--- a/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextData.java
+++ b/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextData.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A mutable thread-safe holder for context scoped logging information.
+ * A mutable thread-safe holder for context-scoped logging information.
  *
  * @see <a href="https://rb.gy/nfnwv">Original Java code of Google Flogger</a>
  */
@@ -45,7 +45,7 @@ final class GrpcContextData {
 
   static Tags getTagsFor(@Nullable GrpcContextData context) {
     if (context != null) {
-      Tags tags = context.tagRef.get();
+      var tags = context.tagRef.get();
       if (tags != null) {
         return tags;
       }
@@ -55,7 +55,7 @@ final class GrpcContextData {
 
   static ContextMetadata getMetadataFor(@Nullable GrpcContextData context) {
     if (context != null) {
-      ContextMetadata metadata = context.metadataRef.get();
+      var metadata = context.metadataRef.get();
       if (metadata != null) {
         return metadata;
       }
@@ -66,7 +66,7 @@ final class GrpcContextData {
   static boolean shouldForceLoggingFor(
       @Nullable GrpcContextData context, String loggerName, Level level) {
     if (context != null) {
-      LogLevelMap map = context.logLevelMapRef.get();
+      var map = context.logLevelMapRef.get();
       if (map != null) {
         return map.getLevel(loggerName).intValue() <= level.intValue();
       }
@@ -136,21 +136,21 @@ final class GrpcContextData {
       GrpcContextDataProvider provider) {
     this.scopes = ScopeList.addScope(parent != null ? parent.scopes : null, scopeType);
     this.tagRef =
-        new ScopedReference<Tags>(parent != null ? parent.tagRef.get() : null) {
+        new ScopedReference<>(parent != null ? parent.tagRef.get() : null) {
           @Override
           Tags merge(Tags current, Tags delta) {
             return current.merge(delta);
           }
         };
     this.metadataRef =
-        new ScopedReference<ContextMetadata>(parent != null ? parent.metadataRef.get() : null) {
+        new ScopedReference<>(parent != null ? parent.metadataRef.get() : null) {
           @Override
           ContextMetadata merge(ContextMetadata current, ContextMetadata delta) {
             return current.concatenate(delta);
           }
         };
     this.logLevelMapRef =
-        new ScopedReference<LogLevelMap>(parent != null ? parent.logLevelMapRef.get() : null) {
+        new ScopedReference<>(parent != null ? parent.logLevelMapRef.get() : null) {
           @Override
           LogLevelMap merge(LogLevelMap current, LogLevelMap delta) {
             return current.merge(delta);

--- a/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextData.java
+++ b/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextData.java
@@ -74,6 +74,24 @@ final class GrpcContextData {
     return false;
   }
 
+  /**
+   * Obtains a custom level set for the logger with the given name via
+   * a {@link LogLevelMap}, if it exists.
+   *
+   * @param loggerName the name of the logger
+   * @return the custom level or {@code null} if there is no map, or the map does not affect
+   *  the level of the given logger
+   */
+  @Nullable
+  Level getMappedLevel(String loggerName) {
+    var map = logLevelMapRef.get();
+    if (map == null) {
+        return null;
+    }
+    var result = map.getLevel(loggerName);
+    return result;
+  }
+
   @Nullable
   static LoggingScope lookupScopeFor(@Nullable GrpcContextData contextData, ScopeType type) {
     return contextData != null ? ScopeList.lookup(contextData.scopes, type) : null;

--- a/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextDataProvider.java
+++ b/contexts/grpc-context/src/main/java/io/spine/logging/context/grpc/GrpcContextDataProvider.java
@@ -125,6 +125,19 @@ public final class GrpcContextDataProvider extends ContextDataProvider {
         && GrpcContextData.shouldForceLoggingFor(currentContext(), loggerName, level);
   }
 
+  @Override
+  public @Nullable Level getMappedLevel(String loggerName) {
+    if (!hasLogLevelMap) {
+      return null;
+    }
+    var context = currentContext();
+    if (context == null) {
+      return null;
+    }
+    var result = context.getMappedLevel(loggerName);
+    return result;
+  }
+
   // Static lazy-holder to avoid needing to call unknown code during Flogger initialization. While
   // gRPC context keys don't trigger any logging now, it's not certain that this is guaranteed.
   private static final class KeyHolder {

--- a/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextData.kt
+++ b/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextData.kt
@@ -39,12 +39,9 @@ import io.spine.logging.flogger.context.Tags
  * The data of a scoped logging context with merging capabilities when
  * contexts are nested.
  *
- * @param scopeType
- *        the type of the scope to be created, or `null` if no type is required.
- * @constructor
- *        creates an instance taking initial values from the currently installed
- *        context data. If there is no current logging context, it initializes
- *        the instance with `null`s.
+ * @param scopeType The type of the scope to be created, or `null` if no type is required.
+ * @constructor Creates an instance taking initial values from the currently installed context data.
+ *   If there is no current logging context, it initializes the instance with `null`s.
  */
 internal class StdContextData(scopeType: ScopeType?) {
 
@@ -163,6 +160,14 @@ internal object CurrentStdContext {
         return false
     }
 
+    /**
+     * Obtains a custom level set for the logger with the given name via [LogLevelMap],
+     * if it exists.
+     *
+     * @param loggerName The name of the logger.
+     * @return The custom level or `null` if there is no map, or the map does not affect
+     *   the level of the given logger.
+     */
     fun mappedLevelOf(loggerName: String): Level? {
         return data?.let {
             it.logLevelMapRef.get()?.levelOf(loggerName)

--- a/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextData.kt
+++ b/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextData.kt
@@ -26,14 +26,14 @@
 
 package io.spine.logging.context.std
 
+import io.spine.logging.Level
+import io.spine.logging.compareTo
+import io.spine.logging.context.LogLevelMap
 import io.spine.logging.flogger.LoggingScope
 import io.spine.logging.flogger.context.ContextMetadata
 import io.spine.logging.flogger.context.ScopeType
 import io.spine.logging.flogger.context.ScopedLoggingContext.ScopeList
 import io.spine.logging.flogger.context.Tags
-import io.spine.logging.Level
-import io.spine.logging.compareTo
-import io.spine.logging.context.LogLevelMap
 
 /**
  * The data of a scoped logging context with merging capabilities when
@@ -161,6 +161,12 @@ internal object CurrentStdContext {
             }
         }
         return false
+    }
+
+    fun mappedLevelOf(loggerName: String): Level? {
+        return data?.let {
+            it.logLevelMapRef.get()?.levelOf(loggerName)
+        }
     }
 
     /**

--- a/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextDataProvider.kt
+++ b/contexts/std-context/src/main/kotlin/io/spine/logging/context/std/StdContextDataProvider.kt
@@ -27,7 +27,6 @@
 package io.spine.logging.context.std
 
 import io.spine.logging.context.toMap
-import io.spine.logging.flogger.FloggerMetadataKey
 import io.spine.logging.flogger.LoggingScope
 import io.spine.logging.flogger.backend.Metadata
 import io.spine.logging.flogger.context.ContextDataProvider
@@ -35,7 +34,9 @@ import io.spine.logging.flogger.context.ScopeType
 import io.spine.logging.flogger.context.ScopedLoggingContext
 import io.spine.logging.flogger.context.ScopedLoggingContext.LoggingContextCloseable
 import io.spine.logging.flogger.context.Tags
+import io.spine.logging.toJavaLogging
 import io.spine.logging.toLevel
+import java.util.logging.Level
 import java.util.logging.Level as JLevel
 
 /**
@@ -65,6 +66,13 @@ public class StdContextDataProvider: ContextDataProvider() {
 
         val level = jLevel.toLevel()
         return CurrentStdContext.shouldForceLoggingFor(loggerName, level)
+    }
+
+    override fun getMappedLevel(loggerName: String): Level? {
+        if (!hasLogLevelMap) {
+            return null
+        }
+        return CurrentStdContext.mappedLevelOf(loggerName)?.toJavaLogging()
     }
 
     override fun getTags(): Tags = CurrentStdContext.tags()

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1679,7 +1679,7 @@ This report was generated on **Tue Oct 22 19:51:19 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3401,7 +3401,7 @@ This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4262,7 +4262,7 @@ This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5119,7 +5119,7 @@ This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5976,7 +5976,7 @@ This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6841,7 +6841,7 @@ This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7710,7 +7710,7 @@ This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8579,7 +8579,7 @@ This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10227,7 +10227,7 @@ This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11076,7 +11076,7 @@ This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12184,7 +12184,7 @@ This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13108,7 +13108,7 @@ This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13965,7 +13965,7 @@ This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14756,4 @@ This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:19 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1679,7 +1679,7 @@ This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3401,7 +3401,7 @@ This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4262,7 +4262,7 @@ This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5119,7 +5119,7 @@ This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5976,7 +5976,7 @@ This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6841,7 +6841,7 @@ This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7710,7 +7710,7 @@ This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8579,7 +8579,7 @@ This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10227,7 +10227,7 @@ This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11076,7 +11076,7 @@ This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12184,7 +12184,7 @@ This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13108,7 +13108,7 @@ This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13965,7 +13965,7 @@ This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14756,4 @@ This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:38:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:51:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1679,7 +1679,7 @@ This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3401,7 +3401,7 @@ This report was generated on **Wed Oct 23 14:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4262,7 +4262,7 @@ This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5119,7 +5119,7 @@ This report was generated on **Wed Oct 23 14:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5976,7 +5976,7 @@ This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6841,7 +6841,7 @@ This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7710,7 +7710,7 @@ This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8579,7 +8579,7 @@ This report was generated on **Wed Oct 23 14:31:13 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10227,7 +10227,7 @@ This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11076,7 +11076,7 @@ This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12184,7 +12184,7 @@ This report was generated on **Wed Oct 23 14:31:14 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13108,7 +13108,7 @@ This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13965,7 +13965,7 @@ This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14756,4 @@ This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:31:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1679,7 +1679,7 @@ This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3401,7 +3401,7 @@ This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4262,7 +4262,7 @@ This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5119,7 +5119,7 @@ This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5976,7 +5976,7 @@ This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6841,7 +6841,7 @@ This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7710,7 +7710,7 @@ This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8579,7 +8579,7 @@ This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10227,7 +10227,7 @@ This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11076,7 +11076,7 @@ This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12184,7 +12184,7 @@ This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13108,7 +13108,7 @@ This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13965,7 +13965,7 @@ This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14756,4 @@ This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1679,7 +1679,7 @@ This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Tue Oct 22 19:31:08 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3401,7 +3401,7 @@ This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:06 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4262,7 +4262,7 @@ This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5119,7 +5119,7 @@ This report was generated on **Tue Oct 22 19:31:09 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5976,7 +5976,7 @@ This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6841,7 +6841,7 @@ This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7710,7 +7710,7 @@ This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8579,7 +8579,7 @@ This report was generated on **Tue Oct 22 19:31:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10227,7 +10227,7 @@ This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11076,7 +11076,7 @@ This report was generated on **Tue Oct 22 19:31:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12184,7 +12184,7 @@ This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13108,7 +13108,7 @@ This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13965,7 +13965,7 @@ This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14756,4 @@ This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 22 19:31:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 19:38:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -814,7 +814,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1061,6 +1061,10 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1436,6 +1440,18 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1679,7 +1695,7 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1921,6 +1937,10 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -2293,6 +2313,18 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2536,7 +2568,7 @@ This report was generated on **Wed Oct 23 14:55:47 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2783,6 +2815,10 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3151,6 +3187,18 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3401,7 +3449,7 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3643,6 +3691,10 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -4019,6 +4071,18 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4262,7 +4326,7 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4505,6 +4569,10 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4876,6 +4944,18 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5119,7 +5199,7 @@ This report was generated on **Wed Oct 23 14:55:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5362,6 +5442,10 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5730,6 +5814,18 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5976,7 +6072,7 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6218,6 +6314,10 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -6587,6 +6687,18 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -6841,7 +6953,7 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7087,6 +7199,10 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -7459,6 +7575,18 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -7710,7 +7838,7 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7960,6 +8088,10 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -8336,6 +8468,18 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -8579,7 +8723,7 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9514,7 @@ This report was generated on **Wed Oct 23 14:55:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9612,6 +9756,10 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -9984,6 +10132,18 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -10227,7 +10387,7 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10469,6 +10629,10 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -10833,6 +10997,18 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -11076,7 +11252,7 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11566,6 +11742,10 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -11937,6 +12117,18 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -12184,7 +12376,7 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12502,6 +12694,10 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -12865,6 +13061,18 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -13108,7 +13316,7 @@ This report was generated on **Wed Oct 23 14:55:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13350,6 +13558,10 @@ This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
@@ -13722,6 +13934,18 @@ This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : gfm-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : jekyll-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -13965,7 +14189,7 @@ This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14756,4 +14980,4 @@ This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 23 14:55:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 23 18:16:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-logging-fixtures:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-fixtures:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-grpc-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-grpc-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1679,12 +1679,12 @@ This report was generated on **Mon Oct 21 18:28:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jul-backend:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jul-backend:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2536,12 +2536,12 @@ This report was generated on **Mon Oct 21 18:28:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:07 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-default-platform:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-default-platform:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3401,12 +3401,12 @@ This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-jul-backend-grpc-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-jul-backend-grpc-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4262,12 +4262,12 @@ This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-jul-backend-std-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-jul-backend-std-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5119,12 +5119,12 @@ This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-log4j2-backend-std-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-log4j2-backend-std-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5976,12 +5976,12 @@ This report was generated on **Mon Oct 21 18:28:49 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-slf4j-jdk14-backend-std-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-slf4j-jdk14-backend-std-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6841,12 +6841,12 @@ This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-jvm-slf4j-reload4j-backend-std-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-jvm-slf4j-reload4j-backend-std-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7710,12 +7710,12 @@ This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-log4j2-backend:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-log4j2-backend:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8579,12 +8579,12 @@ This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:09 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9370,12 +9370,12 @@ This report was generated on **Mon Oct 21 18:28:50 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-middleware:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-middleware:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10227,12 +10227,12 @@ This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-platform-generator:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-platform-generator:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11076,12 +11076,12 @@ This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-probe-backend:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-probe-backend:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.github.ajalt. **Name** : colormath. **Version** : 1.2.0.
@@ -12184,12 +12184,12 @@ This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-smoke-test:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13108,12 +13108,12 @@ This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-logging-std-context:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-logging-std-context:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13965,12 +13965,12 @@ This report was generated on **Mon Oct 21 18:28:51 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-logging:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine.tools:spine-testutil-logging:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14756,4 +14756,4 @@ This report was generated on **Mon Oct 21 18:28:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 18:28:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 22 18:51:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * The basic logging API. An implementation of this API (or an extension of it) will be
- * returned by any fluent logger, and forms the basis of the fluent call chain.
+ * returned by any fluent logger and forms the basis of the fluent call chain.
  * <p>
  * In typical usage each method in the API, with the exception of the terminal {@code log()}
  * statements, will carry out some simple task (which may involve modifying the context of the log
@@ -44,32 +44,34 @@ import java.util.concurrent.TimeUnit;
  * <li>Methods which return an alternate API in order to implement context specific grammar (though
  *     these alternate APIs should always return the original logging API eventually).
  * </ul>
- * A hypothetical example of a context specific grammar might be:
+ * A hypothetical example of a context-specific grammar might be:
  * <pre>{@code
  * logger.at(WARNING).whenSystem().isLowOnMemory().log("");
  * }</pre>
- * In this example the {@code whenSystem()} method would return its own API with several context
- * specific methods ({@code isLowOnMemory()}, {@code isThrashing()} etc...), however each of these
- * sub-APIs must eventually return the original logging API.
+ * In this example the {@code whenSystem()} method would return its own API with several
+ * context-specific methods ({@code isLowOnMemory()}, {@code isThrashing()} etc...).
+ * However, each of these sub-APIs must eventually return the original logging API.
  *
  * @see <a href="https://github.com/google/flogger/blob/cb9e836a897d36a78309ee8badf5cad4e6a2d3d8/api/src/main/java/com/google/common/flogger/LoggingApi.java">
  *     Original Java code of Google Flogger</a>
  */
-// NOTE: new methods to this interface should be coordinated with google-java-format
+@SuppressWarnings({"ClassWithTooManyMethods", "OverlyComplexClass"})
 public interface FloggerApi<API extends FloggerApi<API>> {
   /**
    * Associates a {@link Throwable} instance with the current log statement, to be interpreted as
-   * the cause of this statement. Typically this method will be used from within catch blocks to log
+   * the cause of this statement.
+   *
+   * <p>Typically, this method will be used from within catch blocks to log
    * the caught exception or error. If the cause is {@code null} then this method has no effect.
-   * <p>
-   * If this method is called multiple times for a single log statement, the last invocation will
+   *
+   * <p>If this method is called multiple times for a single log statement, the last invocation will
    * take precedence.
    */
   API withCause(@Nullable Throwable cause);
 
   /**
    * Modifies the current log statement to be emitted at most one-in-N times. The specified count
-   * must be greater than zero and it is expected, but not required, that it is constant. In the
+   * must be greater than zero, and it is expected, but not required, that it is constant. In the
    * absence of any other rate limiting, this method always allows the first invocation of any log
    * statement to be emitted.
    *
@@ -144,7 +146,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * logging would occur after {@code 0s}, {@code 2.4s} and {@code 4.8s} (not {@code 4.2s}),
    * giving an effective duration of {@code 2.4s} between log statements over time.
    * <p>
-   * Providing a zero length duration (ie, {@code n == 0}) disables rate limiting and makes this
+   * Providing a zero-length duration (i.e., {@code n == 0}) disables rate limiting and makes this
    * method an effective no-op.
    *
    * <h3>Granularity</h3>
@@ -235,7 +237,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * Aggregates stateful logging with respect to the given enum value.
    *
    * <p>Normally log statements with conditional behaviour (e.g. rate limiting) use the same state
-   * for each invocation (e.g. counters or timestamps). This method allows an additional qualifier
+   * for each invocation (e.g., counters or timestamps). This method allows an additional qualifier
    * to be given which allows for different conditional state for each unique qualifier.
    *
    * <p>This only makes a difference for log statements which use persistent state to control
@@ -291,7 +293,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * the current scope.
    *
    * <p>If a log statement using this method is invoked outside a context of the given type, this
-   * call has no effect (e.g. rate limiting will apply normally, without respect to any specific
+   * call has no effect (e.g., rate limiting will apply normally, without respect to any specific
    * scope).
    *
    * <p>If multiple aggregation keys are added to a single log statement, then they all take effect
@@ -334,7 +336,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * repeating non-repeatable keys).
    *
    * <p>If {@code value} is {@code null}, this method is a no-op. This is useful for specifying
-   * conditional values (e.g. via {@code logger.atInfo().with(MY_KEY, getValueOrNull()).log(...)}).
+   * conditional values (e.g., via {@code logger.atInfo().with(MY_KEY, getValueOrNull()).log(...)}).
    *
    * @param key the metadata key (expected to be a static constant)
    * @param value a value to be associated with the key in this log statement. Null values are
@@ -369,7 +371,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * Sets the log site for the current log statement. Explicit log site injection is very rarely
    * necessary, since either the log site is injected automatically, or it is determined at runtime
    * via stack analysis. The one use case where calling this method explicitly may be useful is when
-   * making logging helper methods, where some common project specific logging behavior is
+   * making logging helper methods, where some common project-specific logging behavior is
    * enshrined. For example, you can write:
    *
    * <pre>{@code
@@ -458,9 +460,10 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * <pre>{@code logger.atFine().every(100).isEnabled()}</pre>
    * is incorrect because it will always behave identically to:
    * <pre>{@code logger.atFine().isEnabled()}</pre>
-   * <p>
+   *
    * <h3>Implementation Note</h3>
-   * By avoiding passing a separate {@code Level} at runtime to determine "loggability", this API
+   *
+   * <p>By avoiding passing a separate {@code Level} at runtime to determine "loggability", this API
    * makes it easier to coerce bytecode optimizers into doing "dead code" removal on sections
    * guarded by this method.
    * <p>
@@ -489,13 +492,13 @@ public interface FloggerApi<API extends FloggerApi<API>> {
 
   /**
    * Terminal log statement when a message is not required. A {@code log} method must terminate all
-   * fluent logging chains and the no-argument method can be used if there is no need for a log
+   * fluent logging chains, and the no-argument method can be used if there is no need for a log
    * message. For example:
    * <pre>{@code
    * logger.at(INFO).withCause(error).log();
    * }</pre>
    * <p>
-   * However as it is good practice to give all log statements a meaningful log message, use of this
+   * However, as it is good practice to give all log statements a meaningful log message, use of this
    * method should be rare.
    */
   void log();
@@ -504,7 +507,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * Logs the given literal string without interpreting any argument placeholders.
    * <p>
    * Important: This is intended only for use with hard-coded, literal strings which cannot
-   * contain user data. If you wish to log user generated data, you should do something like:
+   * contain user data. If you wish to log user-generated data, you should do something like:
    * <pre>{@code
    * log("user data=%s", value);
    * }</pre>
@@ -523,7 +526,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * logger's choice of parser.
    * <p>
    * Note that printf-style loggers are always expected to accept the standard Java printf
-   * formatting characters (e.g. "%s", "%d" etc...) and all flags unless otherwise stated.
+   * formatting characters (e.g. "%s", "%d", etc...) and all flags unless otherwise stated.
    * Null arguments are formatted as the literal string {@code "null"} regardless of
    * formatting flags.
    *

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
@@ -297,8 +297,8 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * <p>If multiple aggregation keys are added to a single log statement, then they all take effect
    * and logging is aggregated by the unique combination of keys passed to all "per" methods.
    *
-   * @param scopeProvider a constant used to defined the type of the scope in which logging is
-   *     aggregated.
+   * @param scopeProvider a constant used to define the type of the scope in which
+   *                     logging is aggregated.
    */
   API per(LoggingScopeProvider scopeProvider);
 

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/FloggerApi.java
@@ -298,7 +298,7 @@ public interface FloggerApi<API extends FloggerApi<API>> {
    * and logging is aggregated by the unique combination of keys passed to all "per" methods.
    *
    * @param scopeProvider a constant used to define the type of the scope in which
-   *                     logging is aggregated.
+   *     logging is aggregated.
    */
   API per(LoggingScopeProvider scopeProvider);
 

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/FluentLogger2.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/FluentLogger2.java
@@ -98,7 +98,7 @@ public final class FluentLogger2 extends AbstractLogger<FluentLogger2.Api> {
   public Api at(Level level) {
     var loggerName = getName();
     var mappedLevel = Platform.getMappedLevel(loggerName);
-    if (Level.OFF.equals(mappedLevel)) {
+    if (io.spine.logging.Level.Companion.getOFF().equals(mappedLevel)) {
       return NO_OP;
     }
     var isLoggable = isLoggable(level);

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/FluentLogger2.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/FluentLogger2.java
@@ -96,8 +96,13 @@ public final class FluentLogger2 extends AbstractLogger<FluentLogger2.Api> {
 
   @Override
   public Api at(Level level) {
+    var loggerName = getName();
+    var mappedLevel = Platform.getMappedLevel(loggerName);
+    if (Level.OFF.equals(mappedLevel)) {
+      return NO_OP;
+    }
     var isLoggable = isLoggable(level);
-    var isForced = Platform.shouldForceLogging(getName(), level, isLoggable);
+    var isForced = Platform.shouldForceLogging(loggerName, level, isLoggable);
     return (isLoggable || isForced) ? new Context(level, isForced) : NO_OP;
   }
 

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/LogPerBucketingStrategy.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/LogPerBucketingStrategy.java
@@ -186,9 +186,10 @@ public abstract class LogPerBucketingStrategy<T> {
    * <p>To avoid unwanted allocation at log sites, users are strongly encouraged to assign the
    * returned value to a static field, and pass that to any log statements which need it.
    */
-  public static final LogPerBucketingStrategy<Object> byHashCode(final int maxBuckets) {
+  public static LogPerBucketingStrategy<Object> byHashCode(final int maxBuckets) {
     checkArgument(maxBuckets > 0, "maxBuckets must be positive");
-    return new LogPerBucketingStrategy<Object>("ByHashCode(" + maxBuckets + ")") {
+    return new LogPerBucketingStrategy<Object>("ByHashCode(" + maxBuckets + ')') {
+      @SuppressWarnings("MagicNumber")
       @Override
       protected Object apply(Object key) {
         // Modulo can return -ve values and we want a value in the range (0 <= modulo < maxBuckets).
@@ -222,12 +223,12 @@ public abstract class LogPerBucketingStrategy<T> {
    * requirements and ideally have singleton semantics (e.g. an {@code Enum} or {@code Integer}
    * value).
    *
-   * <p><em>Warning</em>: If keys are not known to have natural singleton semantics (e.g. {@code
-   * String}) then returning the given key instance is generally a bad idea. Even if the set of key
-   * values is small, the set of distinct allocated instances passed to {@link
-   * FloggerApi#per(T,LogPerBucketingStrategy<T>)} can be unbounded, and that's what matters. As
-   * such it is always better to map keys to some singleton identifier or intern the keys in some
-   * way.
+   * <p><em>Warning</em>: If keys are not known to have natural singleton semantics
+   * (e.g. {@code String}) then returning the given key instance is generally a bad idea.
+   * Even if the set of key values is small, the set of distinct allocated instances passed to
+   * {@link FloggerApi#per(T,LogPerBucketingStrategy)} can be unbounded, and that's what matters.
+   * As such, it is always better to map keys to some singleton identifier or intern the keys in
+   * some way.
    *
    * @param key a non-null key from a potentially unbounded set of log aggregation keys.
    * @return an immutable value from some known bounded set, which will be held persistently by
@@ -239,6 +240,6 @@ public abstract class LogPerBucketingStrategy<T> {
 
   @Override
   public final String toString() {
-    return LogPerBucketingStrategy.class.getSimpleName() + "[" + name + "]";
+    return LogPerBucketingStrategy.class.getSimpleName() + '[' + name + ']';
   }
 }

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/RateLimitStatus.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/RateLimitStatus.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Status for rate limiting operations, usable by rate limiters and available to subclasses of
+ * Status for rate-limiting operations, usable by rate limiters and available to subclasses of
  * {@code LogContext} to handle rate limiting consistently.
  *
  * <h2>Design Notes</h2>
@@ -51,7 +51,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <pre>{@code
  * rateLimitStatus = RateLimitStatus.combine(rateLimitStatus, MyCustomRateLimiter.check(...));
- * }>/pre>
+ * }</pre>
  *
  * <p>A rate limiter should switch between two primary states "limiting" and "pending":
  * <ul>
@@ -91,7 +91,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *  }
  *
  *  RateLimitStatus checkRateLimit(MyRateLimitData rateLimitData, ...) {
- *    <update internal state>
+ *    // Update internal state.
  *    return <is-pending> ? this : DISALLOW;
  *  }
  *
@@ -100,7 +100,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *     <reset from "pending" to "limiting" state>
  *   }
  * }
- * }>/pre>
+ * }</pre>
  *
  * <p>The use of {@code LogLevelMap} ensures a rate limiter instance is held separately for each log
  * statement, but it also handles complex garbage collection issues around "specialized" log site
@@ -162,8 +162,8 @@ public abstract class RateLimitStatus {
           }
         };
 
-    static int checkAndGetSkippedCount(
-        RateLimitStatus status, LogSiteKey logSiteKey, Metadata metadata) {
+    private static int checkAndGetSkippedCount(
+            RateLimitStatus status, LogSiteKey logSiteKey, Metadata metadata) {
       LogGuard guard = guardMap.get(logSiteKey, metadata);
       // Pre-increment pendingCount to include this log statement, so (pendingCount > 0).
       int pendingCount = guard.pendingLogCount.incrementAndGet();
@@ -208,7 +208,7 @@ public abstract class RateLimitStatus {
    * </ol>
    *
    * <p>This code ensures that in the normal case of having no rate limiting for a log statement, no
-   * allocations occur. It also ensures that (assuming well written rate limiters) there are no
+   * allocations occur. It also ensures that (assuming well-written rate limiters) there are no
    * allocations for log statements using a single rate limiter.
    */
   @Nullable
@@ -223,7 +223,7 @@ public abstract class RateLimitStatus {
       return a;
     }
     // This is already a rare situation where 2 rate limiters are active for the same log statement.
-    // However in most of these cases, at least one will likley "disallow" logging.
+    // However, in most of these cases, at least one will likley "disallow" logging.
     if (a == DISALLOW || b == ALLOW) {
       return a;
     }

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Metadata.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Metadata.java
@@ -52,7 +52,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public abstract class Metadata {
 
-  /** Returns an immutable {@link Metadata} that has no items. */
+  /** Returns an immutable {@code Metadata} that has no items. */
   public static Metadata empty() {
     return Empty.INSTANCE;
   }
@@ -71,11 +71,15 @@ public abstract class Metadata {
 
     @Override
     public FloggerMetadataKey<?> getKey(int n) {
-      throw new IndexOutOfBoundsException("cannot read from empty metadata");
+      throw cannotReadFromEmpty();
     }
 
     @Override
     public Object getValue(int n) {
+      throw cannotReadFromEmpty();
+    }
+
+    private static IndexOutOfBoundsException cannotReadFromEmpty() {
       throw new IndexOutOfBoundsException("cannot read from empty metadata");
     }
 
@@ -92,14 +96,16 @@ public abstract class Metadata {
   /**
    * Returns the key for the Nth piece of metadata.
    *
-   * @throws IndexOutOfBoundsException if either {@code n < 0} or {n >= getCount()}.
+   * @throws IndexOutOfBoundsException if either {@code n} is negative or {@code n} is greater
+   *  or equal to {@code getCount()}.
    */
   public abstract FloggerMetadataKey<?> getKey(int n);
 
   /**
    * Returns the non-null value for the Nth piece of metadata.
    *
-   * @throws IndexOutOfBoundsException if either {@code n < 0} or {n >= getCount()}.
+   * @throws IndexOutOfBoundsException if either {@code n} is negative or {@code n} is greater
+   *  or equal to {@code getCount()}.
    */
   public abstract Object getValue(int n);
 

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Platform.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, The Flogger Authors; 2023, TeamDev. All rights reserved.
+ * Copyright 2016, The Flogger Authors; 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Platform.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/backend/Platform.java
@@ -255,7 +255,7 @@ public abstract class Platform {
   }
 
   /**
-   * Obtains a custom logging level set to the logger with the given name via
+   * Obtains a custom logging level set for the logger with the given name via
    * a {@link io.spine.logging.flogger.context.LogLevelMap} set in the current logging context.
    *
    * <p>The method returns {@code null} if:

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
@@ -126,6 +126,18 @@ public abstract class ContextDataProvider {
   }
 
   /**
+   * Obtains a custom logging level set for the logger with the given name.
+   *
+   * <p>The default implementation always returns {@code null}.
+   *
+   * @param loggerName the name of the logger
+   * @return the custom level set for the logger or {@ode null} if the level is not set
+   */
+  public @Nullable Level getMappedLevel(String loggerName) {
+    return null;
+  }
+
+  /**
    * Returns a set of tags to be added to a log statement. These tags can be used to provide
    * additional contextual metadata to log statements (e.g. request IDs).
    *

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
@@ -142,7 +142,7 @@ public abstract class ContextDataProvider {
 
   /**
    * Returns a set of tags to be added to a log statement. These tags can be used to provide
-   * additional contextual metadata to log statements (e.g. request IDs).
+   * additional contextual metadata to log statements (e.g., request IDs).
    *
    * <p>Implementations which do not support scoped {@link Tags} should not override this method;
    * the default implementation returns {@code Tags.empty()}.

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
@@ -131,7 +131,7 @@ public abstract class ContextDataProvider {
    * <p>The default implementation always returns {@code null}.
    *
    * @param loggerName the name of the logger
-   * @return the custom level set for the logger or {@ode null} if the level is not set
+   * @return the custom level set for the logger or {@code null} if the level is not set
    */
   public @Nullable Level getMappedLevel(String loggerName) {
     return null;

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ContextDataProvider.java
@@ -33,27 +33,29 @@ import java.util.logging.Level;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * An API for injecting scoped metadata for log statements (either globally or on a per-request
- * basis). Thiis class is not a public API and should never need to be invoked directly by
+ * An API for injecting scoped metadata for log statements (either globally or on
+ * a per-request basis).
+ *
+ * <p>This class is not a public API and should never need to be invoked directly by
  * application code.
  *
- * <p>Note that since this class (and any installed implementation sub-class) is loaded when the
+ * <p>Note that since this class (and any installed implementation subclass) is loaded when the
  * logging platform is loaded, care must be taken to avoid cyclic references during static
- * initialisation. This means that no static fields or static initialization can reference fluent
+ * initialization. This means that no static fields or static initialization can reference fluent
  * loggers or the logging platform (either directly or indirectly).
  *
  * <h2>This is a service type</h2>
  *
- * <p>This type is considered a <i>service type</i> and implemenations may be loaded from the
+ * <p>This type is considered a <i>service type</i> and implementations may be loaded from the
  * classpath via {@link java.util.ServiceLoader} provided the proper service metadata is included in
  * the jar file containing the implementation. When creating an implementation of this class, you
- * can provide serivce metadata (and thereby allow users to get your implementation just by
- * including your jar file) by either manually including a {@code
- * META-INF/services/io.spine.logging.flogger.context.ContextDataProvider} file containing the name
- * of your implementation class or by annotating your implementation class using <a
- * href="https://github.com/google/auto/tree/master/service">
- * {@code @AutoService(ContextDataProvider.class)}</a>. See the documentation
- * of both {@link java.util.ServiceLoader} and {@code DefaultPlatform}
+ * can provide service metadata (and thereby allow users to get your implementation just by
+ * including your jar file) by either manually including
+ * a {@code META-INF/services/io.spine.logging.flogger.context.ContextDataProvider} file
+ * containing the name of your implementation class or by annotating your implementation class
+ * using <a href="https://github.com/google/auto/tree/master/service">
+ * {@code @AutoService(ContextDataProvider.class)}</a>.
+ * See the documentation of both {@link java.util.ServiceLoader} and {@code DefaultPlatform}
  * for more information.
  *
  * @see <a href="https://github.com/google/flogger/blob/cb9e836a897d36a78309ee8badf5cad4e6a2d3d8/api/src/main/java/com/google/common/flogger/context/ContextDataProvider.java">
@@ -86,18 +88,19 @@ public abstract class ContextDataProvider {
    * within an application. This method should be overridden by subclasses to provide the specific
    * implementation of the API.
    *
-   * <p>This method should never be called directly (other than in tests) and users should always go
-   * via {@link ScopedLoggingContext#getInstance}, without needing to reference this class at all.
+   * <p>This method should never be called directly (other than in tests), and users should
+   * always go via {@link ScopedLoggingContext#getInstance}, without needing to reference
+   * this class at all.
    *
    * <p>If an implementation wishes to allow logging from the context API class, that class must be
-   * lazily loaded when this method is called (e.g. using a "lazy holder"). Failure to do so is
+   * lazily loaded when this method is called (e.g., using a "lazy holder"). Failure to do so is
    * likely to result in errors during the initialization of the logging platform classes.
    */
   public abstract ScopedLoggingContext getContextApiSingleton();
 
   /**
    * Returns whether the given logger should have logging forced at the specified level. When
-   * logging is forced for a log statement it will be emitted regardless or the normal log level
+   * logging is forced for a log statement, it will be emitted regardless or the normal log level
    * configuration of the logger and ignoring any rate limiting or other filtering.
    *
    * <p>Implementations which do not support forced logging should not override this method; the
@@ -110,8 +113,8 @@ public abstract class ContextDataProvider {
    * <p>{@code isEnabledByLevel} indicates that the log statement is enabled according to its log
    * level, but a {@code true} value does not necessarily indicate that logging will occur, due to
    * rate limiting or other conditional logging mechanisms. To bypass conditional logging and ensure
-   * that an enabled log statement will be emitted, this method should return {@code true} if {@code
-   * isEnabledByLevel} was {@code true}.
+   * that an enabled log statement will be emitted, this method should return {@code true} if
+   * {@code isEnabledByLevel} was {@code true}.
    *
    * <p>WARNING: This method MUST complete quickly and without allocating any memory. It is invoked
    * for every log statement regardless of logging configuration, so any implementation must go to

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopeType.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopeType.java
@@ -46,8 +46,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public final class ScopeType implements LoggingScopeProvider {
   /**
-   * The built in "request" scope. This can be bound to a scoped context in order to provide a
-   * distinct request scope for each context, allowing stateful logging operations (e.g. rate
+   * The built-in "request" scope. This can be bound to a scoped context in order to provide a
+   * distinct request scope for each context, allowing stateful logging operations (e.g., rate
    * limiting) to be scoped to the current request.
    *
    * <p>Enable a request scope using:

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopedLoggingContext.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopedLoggingContext.java
@@ -367,7 +367,7 @@ public abstract class ScopedLoggingContext {
    *
    * <p>This method is the same as {@link #newContext()} except it additionally binds a new {@link
    * ScopeType} instance to the newly created context. This allows log statements to control
-   * stateful logging operations (e.g. rate limiting) using
+   * stateful logging operations (e.g., rate limiting) using
    * {@link FloggerApi#per(ScopeType) per(ScopeType)} method.
    *
    * <p>Note for users: if you don't need an instance of {@code ScopedLoggingContext} for some

--- a/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopedLoggingContext.java
+++ b/flogger/middleware/src/main/java/io/spine/logging/flogger/context/ScopedLoggingContext.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Callable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A user facing API for creating and modifying scoped logging contexts in applications.
+ * A user-facing API for creating and modifying scoped logging contexts in applications.
  *
  * <p>Scoped contexts provide a way for application code to attach metadata and control the
  * behaviour of logging within well defined contexts. This is most often associated with making "per
@@ -55,14 +55,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * be available to logging as long as the context is installed.
  *
  * <p>Note that in the current API contexts are also modifiable after creation, but this usage is
- * discouraged and may be removed in future. The problem with modifying contexts after creation is
- * that, since contexts can be shared between threads, it is potentially confusing if tags are added
- * to a context when it is being used concurrently by multiple threads.
+ * discouraged and may be removed in the future. The problem with modifying contexts after creation
+ * is that, since contexts can be shared between threads, it is potentially confusing if tags are
+ * added to a context when it is being used concurrently by multiple threads.
  *
  * <p>Note that since logging contexts are designed to be modified by code in libraries and helper
  * functions which do not know about each other, the data structures and behaviour of logging
- * contexts are carefully designed to avoid any accidental "undoing" of existing behaviour. In
- * particular:
+ * contexts are carefully designed to avoid any accidental "undoing" of existing behaviour.
+ * In particular:
  *
  * <ul>
  *   <li>Tags can only be added to contexts, never modified or removed.
@@ -70,13 +70,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * </ul>
  *
  * <p>One possibly surprising result of this behaviour is that it's not possible to disable logging
- * from within a context. However this is quite intentional, since overly verbose logging should be
+ * from within a context. However, this is quite intentional, since overly verbose logging should be
  * fixed by other mechanisms (code changes, global logging configuration), and not on a "per
  * request" basis.
  *
  * <p>Depending on the framework used, it's possible that the current logging context will be
- * automatically propagated to some or all threads or sub-tasks started from within the context.
- * This is not guaranteed however and the semantic behaviour of context propagation is not defined
+ * automatically propagated to some or all threads or subtasks started from within the context.
+ * This is not guaranteed, however, and the semantic behaviour of context propagation is not defined
  * by this class.
  *
  * <p>In particular, if you haven't explicitly opened a context in which to run your code, there is
@@ -86,8 +86,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>Context support and automatic propagation is heavily reliant on Java platform capabilities,
  * and precise behaviour is likely to differ between runtime environments or frameworks. Context
  * propagation may not behave the same everywhere, and in some situations logging contexts may not
- * be supported at all. Methods which attempt to affect context state may do nothing in some
- * environments, or when called at some points in an application. If application code relies on
+ * be supported at all. Methods which attempt to affect a context state may do nothing in some
+ * environments or when called at some points in an application. If application code relies on
  * modifications to an existing, implicit logging context, it should always check the return values
  * of any modification methods called (e.g. {@link #addTags(Tags)}).
  *

--- a/flogger/middleware/src/test/kotlin/io/spine/logging/flogger/FluentLogger2Spec.kt
+++ b/flogger/middleware/src/test/kotlin/io/spine/logging/flogger/FluentLogger2Spec.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -81,7 +81,7 @@ internal class FluentLogger2Spec {
         logger.atWarning().shouldBeInstanceOf<FluentLogger2.Context>()
         logger.atInfo().shouldBeInstanceOf<FluentLogger2.Context>()
 
-        // Below the configured log level you only get no-op instances.
+        // Below the configured log level, you only get no-op instances.
         logger.atFine().shouldBeInstanceOf<FloggerApi.NoOp<*>>()
         logger.atFiner().shouldBeInstanceOf<FloggerApi.NoOp<*>>()
         logger.atFinest().shouldBeInstanceOf<FloggerApi.NoOp<*>>()

--- a/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/Logger.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -33,12 +33,10 @@ import kotlin.reflect.KClass
  * Base class for fluent API loggers.
  *
  * A logger is a factory of fluent logging [API] instances,
- * which allow to build log statements via method chaining.
+ * which allow building log statements via method chaining.
  *
- * @param [API]
- *          the logging API provided by this logger.
- * @param [cls]
- *          the class which is going to perform the logging operations using this logger.
+ * @param [API] The logging API provided by this logger.
+ * @param [cls] The class which is going to perform the logging operations using this logger.
  * @see [LoggingApi]
  */
 public abstract class Logger<API: LoggingApi<API>>(
@@ -77,7 +75,7 @@ public abstract class Logger<API: LoggingApi<API>>(
      * IMPLEMENTATION NOTE
      *
      * The following methods are not implemented as extension functions in order to
-     * preserve the calling site which is supposed to be set by `createApi()` method
+     * preserve the calling site, which is supposed to be set by `createApi()` method
      * of the concrete logger implementation.
      *
      * Had we implemented these methods as extension functions, the calling site would

--- a/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
+++ b/logging/src/commonMain/kotlin/io/spine/logging/LoggingApi.kt
@@ -147,8 +147,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * 2. If this method is called multiple times for a single log statement,
      * the last invocation will take precedence.
      *
-     * @throws IllegalArgumentException
-     *          if `n` is negative or zero
+     * @throws IllegalArgumentException If `n` is negative or zero.
      */
     public fun every(n: Int): API
 
@@ -188,7 +187,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * logging would occur after 0s, 2.4s and 4.8s (not 4.2s), giving an effective
      * duration of 2.4s between log statements over time.
      *
-     * Providing a zero length duration (`n` == 0) does not affect a log statement.
+     * Providing a zero-length duration (`n` == 0) does not affect a log statement.
      * Previously configured rate limitation is used, if any. Such a call should be
      * considered as a no-op.
      *
@@ -211,8 +210,7 @@ public interface LoggingApi<API: LoggingApi<API>> {
      * 2. If this method is called multiple times for a single log statement,
      * the last invocation will take precedence.
      *
-     * @throws IllegalArgumentException
-     *          if `n` is negative
+     * @throws IllegalArgumentException If `n` is negative.
      */
     public fun atMostEvery(n: Int, unit: DurationUnit): API
 

--- a/platforms/jvm-default-platform/src/test/kotlin/io/spine/logging/backend/system/DefaultPlatformSpec.kt
+++ b/platforms/jvm-default-platform/src/test/kotlin/io/spine/logging/backend/system/DefaultPlatformSpec.kt
@@ -29,8 +29,8 @@ package io.spine.logging.backend.system
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeSameInstanceAs
-import io.spine.logging.backend.system.given.MemoizingLoggerBackendFactory
 import io.spine.logging.backend.system.given.FixedTime
+import io.spine.logging.backend.system.given.MemoizingLoggerBackendFactory
 import io.spine.logging.backend.system.given.NoOpCallerFinder
 import io.spine.logging.backend.system.given.StubBackendFactoryService
 import io.spine.logging.backend.system.given.StubClockService

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-logging</artifactId>
-<version>2.0.0-SNAPSHOT.236</version>
+<version>2.0.0-SNAPSHOT.237</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,21 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>gfm-plugin</artifactId>
+    <version>1.9.20</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>javadoc-plugin</artifactId>
+    <version>1.9.20</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>jekyll-plugin</artifactId>
+    <version>1.9.20</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
     <artifactId>kotlin-as-java-plugin</artifactId>
     <version>1.9.20</version>
   </dependency>

--- a/tests/fixtures/src/commonMain/kotlin/io/spine/logging/context/AbstractLogLevelMapTest.kt
+++ b/tests/fixtures/src/commonMain/kotlin/io/spine/logging/context/AbstractLogLevelMapTest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -39,7 +39,7 @@ import kotlin.reflect.full.createInstance
 /**
  * Base class for integration test suites of [LogLevelMap].
  *
- * This class is responsible for the general purpose configuration of a test suite.
+ * This class is responsible for the general-purpose configuration of a test suite.
  * For the actual definition of tests, please see [BaseLogLevelMapTest].
  *
  * @see BaseLogLevelMapTest
@@ -98,13 +98,10 @@ public abstract class AbstractLogLevelMapTest(
     /**
      * Executes the [test] with the started logging [Recorder].
      *
-     * @param T the type of the logging test fixture to be used in the test.
-     * @param displayName
-     *         the name of the test.
-     * @param loggingClass
-     *         the class of the logging test fixture used in the test.
-     * @param test
-     *         the block with the testing code.
+     * @param T The type of the logging test fixture to be used in the test.
+     * @param displayName The name of the test.
+     * @param loggingClass The class of the logging test fixture used in the test.
+     * @param test The block with the testing code.
      */
     protected fun <T: LoggingTestFixture> should(
         displayName: String,
@@ -123,13 +120,10 @@ public abstract class AbstractLogLevelMapTest(
     /**
      * Executes the [test] with fixtures created for the given [loggingClasses].
      *
-     * @param T the type of the logging test fixtures to be used in the test.
-     * @param displayName
-     *         the name of the test.
-     * @param loggingClasses
-     *         the classes of the logging test fixture used in the test.
-     * @param test
-     *         the block with the testing code.
+     * @param T The type of the logging test fixtures to be used in the test.
+     * @param displayName The name of the test.
+     * @param loggingClasses The classes of the logging test fixture used in the test.
+     * @param test The block with the testing code.
      */
     protected fun <T : LoggingTestFixture> shouldMany(
         displayName: String,

--- a/tests/fixtures/src/jvmMain/kotlin/io/spine/logging/context/LoggerTest.kt
+++ b/tests/fixtures/src/jvmMain/kotlin/io/spine/logging/context/LoggerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.logging.context
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.string.shouldNotContain
+import io.spine.logging.Level
+import io.spine.logging.Logger
+import io.spine.logging.LoggingFactory
+import io.spine.logging.testing.tapConsole
+import kotlin.reflect.KClass
+
+/**
+ * Abstract base for testing [Logger] implementations in test suites covering
+ * combinations of backends and contexts.
+ *
+ * @property cls The class for which the [logger] is created.
+ *   Must have the [qualified name][KClass.qualifiedName].
+ */
+public abstract class LoggerTest(
+    protected val cls: KClass<*>,
+    body: ShouldSpec.() -> Unit = {}
+) : ShouldSpec(body) {
+
+    /**
+     * The logger under the test, which is created for the [given class][cls].
+     */
+    protected val logger: Logger<*> = LoggingFactory.forEnclosingClass()
+
+    init {
+        @Suppress("LeakingThis")
+        should("not log if the `Level.OFF` is set via a map") {
+            val map = mapOf(cls.qualifiedName!! to Level.OFF)
+            val levelMap = LogLevelMap.create(map)
+            val logMessage = "This should not be logged."
+            var consoleOutput = ""
+            ScopedLoggingContext.newContext().withLogLevelMap(levelMap).execute {
+                consoleOutput = tapConsole {
+                    logger.atError().log {
+                        logMessage
+                    }
+                }
+            }
+            consoleOutput shouldNotContain logMessage
+        }
+    }
+}

--- a/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LogLevelMapITest.kt
+++ b/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LogLevelMapITest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.logging.context.JulLogLevelMapTest
+
+/**
+ * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
+ * executed in the project in which logging contexts implemented using gRPC.
+ *
+ * Please see `build.gradle.kts` of this module for the details.
+ */
+internal class LogLevelMapITest: JulLogLevelMapTest()

--- a/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LogLevelMapOnGrpcContextTest.kt
+++ b/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LogLevelMapOnGrpcContextTest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LoggerITest.kt
+++ b/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LoggerITest.kt
@@ -26,4 +26,4 @@
 
 import io.spine.logging.context.LoggerTest
 
-internal class LoggerOnGrpcContextTest : LoggerTest(LoggerOnGrpcContextTest::class)
+internal class LoggerITest : LoggerTest(LoggerITest::class)

--- a/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LoggerOnGrpcContextTest.kt
+++ b/tests/jvm-jul-backend-grpc-context/src/test/kotlin/LoggerOnGrpcContextTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.logging.context.LoggerTest
+
+internal class LoggerOnGrpcContextTest : LoggerTest(LoggerOnGrpcContextTest::class)

--- a/tests/jvm-jul-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
+++ b/tests/jvm-jul-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
@@ -29,7 +29,6 @@ import io.kotest.matchers.shouldBe
 import io.spine.logging.backend.jul.JulBackendFactory
 import io.spine.logging.context.JulLogLevelMapTest
 import io.spine.logging.context.std.StdContextDataProvider
-import org.junit.jupiter.api.Test
 
 /**
  * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
@@ -39,17 +38,17 @@ import org.junit.jupiter.api.Test
  */
 internal class LogLevelMapITest : JulLogLevelMapTest() {
 
-    @Test
-    fun `should use 'JulBackendFactory`() {
-        val loggerName = this::class.qualifiedName!!
-        val platformProvided = Platform.getBackend(loggerName)
-        val factoryProvided = JulBackendFactory().create(loggerName)
-        platformProvided::class shouldBe factoryProvided::class
-    }
+    init {
+        should("use `JulBackendFactory`") {
+            val loggerName = this::class.qualifiedName!!
+            val platformProvided = Platform.getBackend(loggerName)
+            val factoryProvided = JulBackendFactory().create(loggerName)
+            platformProvided::class shouldBe factoryProvided::class
+        }
 
-    @Test
-    fun `should use 'StdContextDataProvider'`() {
-        val provider = Platform.getContextDataProvider()
-        provider::class shouldBe StdContextDataProvider::class
+        should("use `StdContextDataProvider`") {
+            val provider = Platform.getContextDataProvider()
+            provider::class shouldBe StdContextDataProvider::class
+        }
     }
 }

--- a/tests/jvm-jul-backend-std-context/src/test/kotlin/LoggerITest.kt
+++ b/tests/jvm-jul-backend-std-context/src/test/kotlin/LoggerITest.kt
@@ -1,0 +1,30 @@
+
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.logging.context.LoggerTest
+
+internal class LoggerITest : LoggerTest(LoggerITest::class)

--- a/tests/jvm-log4j2-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
+++ b/tests/jvm-log4j2-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
@@ -24,12 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.logging.context.JulLogLevelMapTest
+import io.spine.logging.flogger.backend.Platform
+import io.kotest.matchers.shouldBe
+import io.spine.logging.Level
+import io.spine.logging.backend.log4j2.Log4j2BackendFactory
+import io.spine.logging.context.BaseLogLevelMapTest
+import io.spine.logging.context.std.StdContextDataProvider
+import io.spine.logging.testing.Log4j2Recorder
+import io.spine.logging.testing.Recorder
+import org.junit.jupiter.api.Test
 
 /**
  * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
- * executed in the project in which logging contexts implemented using gRPC.
+ * executed in the project in which logging backend is based on Log4j2.
  *
  * Please see `build.gradle.kts` of this module for the details.
  */
-internal class LogLevelMapOnGrpcContextTest: JulLogLevelMapTest()
+internal class LogLevelMapITest: BaseLogLevelMapTest() {
+
+    override fun createRecorder(loggerName: String, minLevel: Level): Recorder =
+        Log4j2Recorder(loggerName, minLevel)
+
+    @Test
+    fun `should use 'Log4j2LoggerBackend`() {
+        val loggerName = this::class.qualifiedName!!
+        val platformProvided = Platform.getBackend(loggerName)
+        val factoryProvided = Log4j2BackendFactory().create(loggerName)
+        platformProvided::class shouldBe factoryProvided::class
+    }
+
+    @Test
+    fun `should use 'StdContextDataProvider'`() {
+        val provider = Platform.getContextDataProvider()
+        provider::class shouldBe StdContextDataProvider::class
+    }
+}

--- a/tests/jvm-log4j2-backend-std-context/src/test/kotlin/LoggerITest.kt
+++ b/tests/jvm-log4j2-backend-std-context/src/test/kotlin/LoggerITest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,25 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.kotest.core.annotation.Ignored
-import io.spine.logging.Level
-import io.spine.logging.context.BaseLogLevelMapTest
-import io.spine.logging.testing.Recorder
+import io.spine.logging.context.LoggerTest
 
-/**
- * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
- * executed in the project with SLF4J backend and `spine-logging-std-context`.
- * SLF4J uses Reload4J logging.
- *
- * Please see `build.gradle.kts` of this module for the details.
- */
-@Ignored // Until recording for Reload4J is implemented.
-@Suppress("unused") // Until SLF4J backend is added.
-internal class LogLevelMapSlf4JOnReload4JTest: BaseLogLevelMapTest() {
-
-    // TODO:2023-10-10:yevhenii.nadtochii: Make this test work when SLF4J backend is added.
-    //  See issue: https://github.com/SpineEventEngine/logging/issues/77
-    override fun createRecorder(loggerName: String, minLevel: Level): Recorder {
-        error("Not implemented.")
-    }
-}
+class LoggerITest : LoggerTest(LoggerITest::class)

--- a/tests/jvm-slf4j-jdk14-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
+++ b/tests/jvm-slf4j-jdk14-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.kotest.core.annotation.Ignored
+import io.spine.logging.Level
+import io.spine.logging.context.BaseLogLevelMapTest
+import io.spine.logging.testing.Recorder
+
+/**
+ * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
+ * executed in the project with SLF4J backend and `spine-logging-std-context`.
+ * SLF4J uses JDK 1.4 logging (`java.util.logging`, JUL).
+ *
+ * Please see `build.gradle.kts` of this module for the details.
+ */
+@Ignored // Until recording for SLF4J is implemented.
+@Suppress("unused") // Until SLF4J backend is added.
+internal class LogLevelMapITest: BaseLogLevelMapTest() {
+
+    // TODO:2023-10-10:yevhenii.nadtochii: Make this test work when SLF4J backend is added.
+    //  See issue: https://github.com/SpineEventEngine/logging/issues/77
+    override fun createRecorder(loggerName: String, minLevel: Level): Recorder {
+        error("Not implemented.")
+    }
+}

--- a/tests/jvm-slf4j-jdk14-backend-std-context/src/test/kotlin/LoggerITest.kt
+++ b/tests/jvm-slf4j-jdk14-backend-std-context/src/test/kotlin/LoggerITest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,25 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.kotest.core.annotation.Ignored
-import io.spine.logging.Level
-import io.spine.logging.context.BaseLogLevelMapTest
-import io.spine.logging.testing.Recorder
+import io.spine.logging.context.LoggerTest
 
-/**
- * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
- * executed in the project with SLF4J backend and `spine-logging-std-context`.
- * SLF4J uses JDK 1.4 logging (`java.util.logging`, JUL).
- *
- * Please see `build.gradle.kts` of this module for the details.
- */
-@Ignored // Until recording for SLF4J is implemented.
-@Suppress("unused") // Until SLF4J backend is added.
-internal class LogLevelMapSlf4JOnJdk14Test: BaseLogLevelMapTest() {
-
-    // TODO:2023-10-10:yevhenii.nadtochii: Make this test work when SLF4J backend is added.
-    //  See issue: https://github.com/SpineEventEngine/logging/issues/77
-    override fun createRecorder(loggerName: String, minLevel: Level): Recorder {
-        error("Not implemented.")
-    }
-}
+class LoggerITest : LoggerTest(LoggerITest::class)

--- a/tests/jvm-slf4j-reload4j-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
+++ b/tests/jvm-slf4j-reload4j-backend-std-context/src/test/kotlin/LogLevelMapITest.kt
@@ -24,38 +24,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.logging.flogger.backend.Platform
-import io.kotest.matchers.shouldBe
+import io.kotest.core.annotation.Ignored
 import io.spine.logging.Level
-import io.spine.logging.backend.log4j2.Log4j2BackendFactory
 import io.spine.logging.context.BaseLogLevelMapTest
-import io.spine.logging.context.std.StdContextDataProvider
-import io.spine.logging.testing.Log4j2Recorder
 import io.spine.logging.testing.Recorder
-import org.junit.jupiter.api.Test
 
 /**
  * This is a non-abstract integration test of [LogLevelMap][io.spine.logging.context.LogLevelMap]
- * executed in the project in which logging backend is based on Log4j2.
+ * executed in the project with SLF4J backend and `spine-logging-std-context`.
+ * SLF4J uses Reload4J logging.
  *
  * Please see `build.gradle.kts` of this module for the details.
  */
-internal class LogLevelMapLog4j2BackendITest: BaseLogLevelMapTest() {
+@Ignored // Until recording for Reload4J is implemented.
+@Suppress("unused") // Until SLF4J backend is added.
+internal class LogLevelMapITest: BaseLogLevelMapTest() {
 
-    override fun createRecorder(loggerName: String, minLevel: Level): Recorder =
-        Log4j2Recorder(loggerName, minLevel)
-
-    @Test
-    fun `should use 'Log4j2LoggerBackend`() {
-        val loggerName = this::class.qualifiedName!!
-        val platformProvided = Platform.getBackend(loggerName)
-        val factoryProvided = Log4j2BackendFactory().create(loggerName)
-        platformProvided::class shouldBe factoryProvided::class
-    }
-
-    @Test
-    fun `should use 'StdContextDataProvider'`() {
-        val provider = Platform.getContextDataProvider()
-        provider::class shouldBe StdContextDataProvider::class
+    // TODO:2023-10-10:yevhenii.nadtochii: Make this test work when SLF4J backend is added.
+    //  See issue: https://github.com/SpineEventEngine/logging/issues/77
+    override fun createRecorder(loggerName: String, minLevel: Level): Recorder {
+        error("Not implemented.")
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.236")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.237")


### PR DESCRIPTION
This PR extends the library with the ability to obtain a custom logging level status set via `LogLevelMap`. Also, `FluentLogger2.at()` method was adjusted to allow turning off the logging via a level forced via a map.

## Changes in details
 * The `Platform` class got `static` method `getMappedLevel()` which allows to obtain the level set via `LogLevelMap`.
 * Correspondingly, `ContextDataProvider` and its implementations got the method `getMappedLevel()`.

## Other notable changes
 * Javadoc warnings and errors appearing in the build console output were addressed.
 * Some warnings and errors highlighted by IDEA were addressed.
 * Simplified names of existing integration tests to end with `ITest`.
